### PR TITLE
Add admin access, notifications, and responsive tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,19 +3,18 @@
 <head>
   <meta charset="UTF-8" /> <!-- codificación UTF-8 -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" /> <!-- responsive -->
-  <title>FISURAS MATEMÁTICAS – Juegos & Cursos</title> <!-- título -->
+  <title>FIGURAS MATEMÁTICAS – Juegos & Cursos</title> <!-- título -->
   <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" /> <!-- enlace a CSS -->
 </head>
 <body>
   <header>
     <div id="ledPhoneTop" class="ledPhone"></div>
-    <h1>FISURAS&nbsp;MATEMÁTICAS</h1> <!-- encabezado principal -->
+    <h1>FIGURAS&nbsp;MATEMÁTICAS</h1> <!-- encabezado principal -->
     <nav>
       <ul>
         <li><a href="#inicio">Inicio</a></li> <!-- enlace a sección inicio -->
         <li><a href="login.html">Acceso</a></li> <!-- enlace a login externo -->
-        <li><a href="correos.html">Correos</a></li> <!-- enlace a correos -->
         <li><a href="#contacto">Contacto</a></li> <!-- enlace a contacto -->
       </ul>
     </nav>
@@ -84,6 +83,8 @@
     </section>
   </main>
   <footer>&copy; 2025 Fisuras Matemáticas – Hōrūz</footer> <!-- pie de página -->
+  <audio id="bgMusic" src="https://actions.google.com/sounds/v1/ambiences/arcade_game.ogg" loop></audio>
+  <div id="notify"></div>
   <script src="scripts.js"></script> <!-- enlace JS -->
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -17,12 +17,17 @@
       <label>Contraseña <input type="password" id="pwd" required /></label>
       <button type="submit">Entrar</button>
     </form>
-    <form id="adminForm" hidden>
-      <label>Nombre del curso <input type="text" id="courseName" /></label>
-      <label>Fecha de inicio <input type="date" id="courseDate" /></label>
-      <label>Precio por sesión <input type="number" id="coursePrice" /></label>
-      <button id="saveCourse" type="button">Guardar</button>
-    </form>
+    <section id="adminPanel" hidden>
+      <form id="adminForm">
+        <label>Nombre del curso <input type="text" id="courseName" /></label>
+        <label>Fecha de inicio <input type="date" id="courseDate" /></label>
+        <label>Precio por sesión <input type="number" id="coursePrice" /></label>
+        <button id="saveCourse" type="button">Guardar</button>
+      </form>
+      <table id="msgTable" class="sheet"></table>
+      <div id="adminFiles" class="drop-zone">Sube o arrastra archivos (PDF o imágenes)</div>
+      <div id="adminFileList"></div>
+    </section>
   </main>
   <footer>&copy; 2025 Fisuras Matemáticas – Hōrūz</footer>
   <script src="scripts.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,7 @@
 body{font-family:"Comic Sans MS",Segoe UI,sans-serif;color:var(--chalk);min-height:100vh;display:flex;flex-direction:column;
   background:var(--bg);
   background-image:radial-gradient(rgba(255,255,255,.05) 1px,transparent 1px),radial-gradient(rgba(255,255,255,.03) 1px,transparent 1px);
-  background-position:0 0,25px 25px;background-size:50px 50px;} /* efecto pizarrón */
+  background-position:0 0,25px 25px;background-size:50px 50px;font-size:1.1rem;line-height:1.6;} /* efecto pizarrón */
 main{width:95%;max-width:1100px;margin:auto;padding:2rem 0}
 
 /* ========= Header ========= */
@@ -64,6 +64,9 @@ canvas{display:block;width:100%;background:var(--bg)}
 .drop-zone.dragover{background:rgba(255,255,255,.15)}
 #preview{max-width:550px;margin:1rem auto;font-size:.85rem;line-height:1.4;color:#ddd}
 
+.sheet{width:100%;border-collapse:collapse;margin-top:1rem;}
+.sheet th,.sheet td{border:1px solid var(--pb);padding:.5rem;text-align:left;}
+
 /* ========= Footer ========= */
 footer{text-align:center;color:#ccc;padding:1rem;margin-top:auto;font-size:.8rem}
 
@@ -76,3 +79,18 @@ form input,form textarea,form select{padding:.3rem;border-radius:6px;border:1px 
 form button{margin-top:.6rem;border:none;border-radius:8px;background:var(--sg);color:#000;padding:.45rem 1rem;font-weight:bold;cursor:pointer;} /* botones de formularios */
 .msg{border:1px dashed var(--pb);padding:1rem;margin:1rem 0;}
 .msg textarea{width:100%;min-height:60px;margin-top:.5rem;}
+
+/* burbuja de notificación */
+#notify{position:fixed;bottom:20px;right:20px;z-index:1000;}
+.bubble{background:rgba(0,0,0,.8);border:2px solid var(--sg);color:var(--chalk);padding:1rem;border-radius:12px;max-width:260px;
+        box-shadow:0 0 10px var(--sg);margin-top:.5rem;}
+
+/* resalta formulario de contacto */
+.highlight{border:4px solid #ff0;box-shadow:0 0 15px #ff0;}
+
+/* disposición responsive del juego */
+@media(max-width:700px){
+  #juego{padding-right:0;display:flex;flex-direction:column;align-items:center;}
+  #controls{position:static;order:2;margin-top:1rem;}
+  #typedDisplay{position:static;order:1;margin-top:.5rem;}
+}


### PR DESCRIPTION
## Summary
- Replace header with "FIGURAS MATEMÁTICAS" and drop extra nav links.
- Add push-style notifications, background music, and course card redirect to the contact form.
- Implement admin panel after password login with message table and personal file uploads.
- Improve responsive layout with keypad repositioning and highlight styles.
- Play explosion sound when bombs hit the ground.

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_688e561a4a1c8325b4a645ad4a3e1f7e