### PR TITLE
Add registration form with Excel export and welcome bubble

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,18 @@
     </nav>
   </header>
   <main>
+    <section id="registro">
+      <h2>REGISTRO RÁPIDO</h2>
+      <form id="registroForm">
+        <label>Nombre <input type="text" name="nombre" required /></label>
+        <label>Teléfono 10 dígitos <input type="tel" name="telefono" pattern="\d{10}" required /></label>
+        <label>Correo electrónico <input type="email" name="correo" required /></label>
+        <button type="submit">Guardar</button>
+      </form>
+      <div style="overflow-x:auto;">
+        <table id="dataTable" class="sheet"></table>
+      </div>
+    </section>
     <section id="inicio"> <!-- sección que agrupa juego y cursos -->
       <div id="juego"> <!-- contenedor del juego -->
         <nav id="opMenu"> <!-- menú para operaciones y dificultad -->
@@ -85,6 +97,7 @@
   <footer>&copy; 2025 Fisuras Matemáticas – Hōrūz</footer> <!-- pie de página -->
   <audio id="bgMusic" src="https://actions.google.com/sounds/v1/ambiences/arcade_game.ogg" loop></audio>
   <div id="notify"></div>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <script src="scripts.js"></script> <!-- enlace JS -->
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -81,9 +81,10 @@ form button{margin-top:.6rem;border:none;border-radius:8px;background:var(--sg);
 .msg textarea{width:100%;min-height:60px;margin-top:.5rem;}
 
 /* burbuja de notificación */
-#notify{position:fixed;bottom:20px;right:20px;z-index:1000;}
+#notify{position:fixed;top:20px;right:20px;z-index:1000;}
 .bubble{background:rgba(0,0,0,.8);border:2px solid var(--sg);color:var(--chalk);padding:1rem;border-radius:12px;max-width:260px;
-        box-shadow:0 0 10px var(--sg);margin-top:.5rem;}
+        box-shadow:0 0 10px var(--sg);margin-top:.5rem;position:relative;}
+.bubble .timer{position:absolute;bottom:6px;right:8px;font-size:.85rem;color:var(--sg);font-weight:bold;}
 
 /* resalta formulario de contacto */
 .highlight{border:4px solid #ff0;box-shadow:0 0 15px #ff0;}


### PR DESCRIPTION
## Summary
- Add top-right welcome bubble with 20-second countdown showing registration total
- Create responsive registration form that validates phone numbers and exports entries to Excel
- Seed registrations with two demo entries to verify spreadsheet integration

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_688f623db0d48325a85d15745238d3e0