### PR TITLE
Add responsive math course store webpage

### DIFF
--- a/store.html
+++ b/store.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Math Courses Store</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin:0;}
+    .navbar {display:flex; flex-wrap:wrap; background:#333;}
+    .nav-link {flex:1; padding:14px; color:#fff; text-align:center; text-decoration:none; cursor:pointer; background:#333; border:none;}
+    .nav-link:hover, .nav-link.active {background:#555;}
+    main {padding:20px;}
+    .tab {display:none;}
+    .tab.active {display:block;}
+    .courses {display:flex; flex-wrap:wrap; gap:20px;}
+    .course-card {flex:1 1 200px; background:#f4f4f4; padding:10px; border-radius:8px;}
+    .notification {position:fixed; top:10px; right:10px; background:#0d6efd; color:#fff; padding:15px; border-radius:8px; box-shadow:0 2px 10px rgba(0,0,0,0.3); z-index:1000;}
+    .notification.fade {opacity:0; transition:opacity 1s ease;}
+    table {width:100%; border-collapse:collapse;}
+    table, th, td {border:1px solid #ccc;}
+    th, td {padding:8px; text-align:left;}
+    form label {display:block; margin:10px 0;}
+    .error {color:red;}
+    .hidden {display:none;}
+    @media (max-width:600px) {
+      .courses {flex-direction:column;}
+      .nav-link {flex:1 1 100%;}
+    }
+  </style>
+</head>
+<body>
+  <div id="notification" class="notification" role="alert">
+    <p id="dateTime"></p>
+    <p id="countdownText">Disappears in <span id="countdown">20</span>s</p>
+    <p id="messageNotice"></p>
+  </div>
+
+  <nav class="navbar">
+    <button class="nav-link active" data-target="home">Home</button>
+    <button class="nav-link" data-target="game">Game & Courses</button>
+    <button class="nav-link" data-target="login">Login</button>
+    <button class="nav-link" data-target="contact">Contact</button>
+  </nav>
+
+  <main>
+    <section id="home" class="tab active">
+      <h1>Welcome to the Math Courses Store</h1>
+      <p>Browse our courses and improve your skills.</p>
+      <div class="courses">
+        <div class="course-card">
+          <h2>Algebra Basics</h2>
+          <p>Learn the fundamentals of algebra.</p>
+          <button>Buy Now</button>
+        </div>
+        <div class="course-card">
+          <h2>Calculus I</h2>
+          <p>Introduction to limits and derivatives.</p>
+          <button>Buy Now</button>
+        </div>
+      </div>
+    </section>
+
+    <section id="game" class="tab">
+      <h2>Quick Math Game</h2>
+      <div id="gameArea"></div>
+      <h2>Upcoming Courses</h2>
+      <ul class="upcoming">
+        <li>Geometry Masterclass - Sept 15, 2025</li>
+        <li>Advanced Algebra - Oct 1, 2025</li>
+        <li>Calculus Workshop - Nov 5, 2025</li>
+      </ul>
+    </section>
+
+    <section id="login" class="tab">
+      <div id="loginForm">
+        <h2>Student Login</h2>
+        <label for="loginPassword">Password:</label>
+        <input type="password" id="loginPassword" aria-label="Password" />
+        <button id="loginBtn">Login</button>
+        <p id="loginError" class="error" aria-live="polite"></p>
+      </div>
+      <div id="spreadsheet" class="hidden">
+        <h2>Student Spreadsheet</h2>
+        <table>
+          <thead>
+            <tr><th>Name</th><th>WhatsApp</th><th>Email</th></tr>
+          </thead>
+          <tbody id="sheetBody">
+            <tr><td contenteditable="true">Jane Doe</td><td contenteditable="true">1234567890</td><td contenteditable="true">jane@example.com</td></tr>
+            <tr><td contenteditable="true">John Smith</td><td contenteditable="true">0987654321</td><td contenteditable="true">john@example.com</td></tr>
+          </tbody>
+        </table>
+        <h3>Add Entry</h3>
+        <form id="addEntryForm">
+          <label>Name: <input type="text" id="newName" required></label>
+          <label>WhatsApp: <input type="tel" id="newWhatsApp" pattern="\d{10}" required></label>
+          <label>Email: <input type="email" id="newEmail" required></label>
+          <button type="submit">Add</button>
+        </form>
+      </div>
+    </section>
+
+    <section id="contact" class="tab">
+      <h2>Contact Us</h2>
+      <form id="contactForm">
+        <label>Name: <input type="text" required></label>
+        <label>Email: <input type="email" required></label>
+        <label>Message: <textarea required></textarea></label>
+        <button type="submit">Send</button>
+      </form>
+      <div class="contact-info">
+        <p>Email: contact@mathcourses.com</p>
+        <p>Phone: +1 555-000-1234</p>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    // Notification bubble
+    function formatDate() {
+      const now = new Date();
+      const dateOptions = {weekday:'long', year:'numeric', month:'long', day:'numeric'};
+      const dateStr = now.toLocaleDateString('en-US', dateOptions);
+      const timeStr = now.toLocaleTimeString('en-US', {hour:'numeric', minute:'2-digit'});
+      return `Today is ${dateStr}, ${timeStr}`;
+    }
+    document.getElementById('dateTime').textContent = formatDate();
+    const hasMessages = true; // change based on actual storage
+    document.getElementById('messageNotice').textContent = hasMessages ?
+      'You have pending messages (protected by dual-password authentication).' :
+      'No new messages.';
+
+    let countdown = 20;
+    const countdownEl = document.getElementById('countdown');
+    const interval = setInterval(() => {
+      countdown--;
+      countdownEl.textContent = countdown;
+      if (countdown <= 0) {
+        clearInterval(interval);
+        const bubble = document.getElementById('notification');
+        bubble.classList.add('fade');
+        setTimeout(() => bubble.remove(), 1000);
+      }
+    }, 1000);
+
+    // Navigation
+    const navLinks = document.querySelectorAll('.nav-link');
+    const tabs = document.querySelectorAll('.tab');
+    navLinks.forEach(link => {
+      link.addEventListener('click', () => {
+        navLinks.forEach(l => l.classList.remove('active'));
+        link.classList.add('active');
+        tabs.forEach(tab => tab.classList.remove('active'));
+        document.getElementById(link.dataset.target).classList.add('active');
+        if (link.dataset.target === 'game') {
+          generateQuestion();
+        }
+      });
+    });
+
+    // Math game
+    function generateQuestion() {
+      const a = Math.floor(Math.random()*10);
+      const b = Math.floor(Math.random()*10);
+      const gameArea = document.getElementById('gameArea');
+      gameArea.innerHTML = `<p>${a} + ${b} = ?</p>
+        <input type="number" id="gameAnswer" />
+        <button id="submitAnswer">Check</button>
+        <p id="gameFeedback"></p>`;
+      document.getElementById('submitAnswer').addEventListener('click', () => {
+        const ans = parseInt(document.getElementById('gameAnswer').value,10);
+        const feedback = document.getElementById('gameFeedback');
+        feedback.textContent = (ans === a + b) ? 'Correct!' : 'Try again.';
+      });
+    }
+
+    // Login
+    document.getElementById('loginBtn').addEventListener('click', () => {
+      const pw = document.getElementById('loginPassword').value;
+      if (pw === '2025' || pw === '1991') {
+        document.getElementById('loginForm').classList.add('hidden');
+        document.getElementById('spreadsheet').classList.remove('hidden');
+      } else {
+        document.getElementById('loginError').textContent = 'Incorrect password.';
+      }
+    });
+
+    // Add entry
+    document.getElementById('addEntryForm').addEventListener('submit', e => {
+      e.preventDefault();
+      const name = document.getElementById('newName').value.trim();
+      const wa = document.getElementById('newWhatsApp').value.trim();
+      const email = document.getElementById('newEmail').value.trim();
+      const row = document.createElement('tr');
+      row.innerHTML = `<td contenteditable="true">${name}</td><td contenteditable="true">${wa}</td><td contenteditable="true">${email}</td>`;
+      document.getElementById('sheetBody').appendChild(row);
+      e.target.reset();
+    });
+
+    // Contact form
+    document.getElementById('contactForm').addEventListener('submit', e => {
+      e.preventDefault();
+      alert('Thank you for your message!');
+      e.target.reset();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add standalone `store.html` implementing math course storefront with top-right notification bubble
- Include math game, upcoming courses, dual-password student login, editable spreadsheet, and contact form

## Testing
- No tests included in repository

------
https://chatgpt.com/codex/tasks/task_e_688f678e35e88325915178e874ddbca3