### PR TITLE
Add speed control and course scheduling with notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" /> <!-- codificación UTF-8 -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" /> <!-- responsive -->
   <title>FIGURAS MATEMÁTICAS – Juegos & Cursos</title> <!-- título -->
-  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Cinzel&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" /> <!-- enlace a CSS -->
 </head>
 <body>
@@ -41,11 +41,12 @@
           <label><input type="checkbox" data-op="÷" checked /> FRACCIONES</label> <!-- opción fracciones -->
           <label><input type="checkbox" data-op="√" checked /> RAÍCES</label> <!-- opción raíces -->
           <label><input type="checkbox" data-op="^" checked /> POTENCIAS</label> <!-- opción potencias -->
-          <label>DIFICULTAD <input type="range" id="difficulty" min="1" max="5" value="1" /></label> <!-- control de dificultad -->
+          <label>DIFICULTAD <input type="range" id="difficulty" min="1" max="5" value="1" /></label>
+          <label>VELOCIDAD <input type="range" id="speed" min="1" max="5" value="3" /></label>
         </nav>
         <div id="gameWrapper"> <!-- marco del canvas -->
           <canvas id="game" width="1000" height="600"></canvas> <!-- canvas para animación -->
-          <div id="hud">Cargando…</div> <!-- marcador -->
+          <div id="hud">Aciertos 0  Errores 5/5</div>
         </div>
         <div id="typedDisplay"></div> <!-- muestra lo escrito -->
         <div id="controls">

--- a/login.html
+++ b/login.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Acceso – Fisuras Matemáticas</title>
-  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Cinzel&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,17 @@
 /* ========= Variables ======== */
 :root{
-  --pb:#4dabf5;           /* primario azul  */
-  --sg:#ffca28;           /* secundario oro */
-  --ac:#81c784;           /* acento verde   */
-  --bg:#064019;           /* pizarrón       */
-  --chalk:#fff;
+  --bg:#0f3b2f;
+  --chalk:#f5e7c8;
+  --sg:#d4af37;           /* dorado */
+  --pb:#2e8b57;           /* verde botones */
+  --ac:#2e8b57;
   --card:rgba(255,255,255,.08);
   --shadow:rgba(0,0,0,.25);
 }
 
 /* ========= Reset / base ===== */
 *{margin:0;padding:0;box-sizing:border-box}
-body{font-family:"Comic Sans MS",Segoe UI,sans-serif;color:var(--chalk);min-height:100vh;display:flex;flex-direction:column;
+body{font-family:"Cinzel",serif;color:var(--chalk);min-height:100vh;display:flex;flex-direction:column;
   background:var(--bg);
   background-image:radial-gradient(rgba(255,255,255,.05) 1px,transparent 1px),radial-gradient(rgba(255,255,255,.03) 1px,transparent 1px);
   background-position:0 0,25px 25px;background-size:50px 50px;font-size:1.1rem;line-height:1.6;} /* efecto pizarrón */
@@ -53,8 +53,9 @@ canvas{display:block;width:100%;background:var(--bg)}
 .card h3{color:var(--pb);margin-bottom:.5rem}
 .card p{font-size:.9rem;margin:.25rem 0}
 .card button.temarioBtn{margin-top:.6rem;border:none;border-radius:8px;background:var(--sg);color:#000;padding:.35rem .9rem;font-weight:bold;cursor:pointer}
+.card button.agendarBtn{margin-top:.6rem;border:none;border-radius:8px;background:var(--pb);color:#000;padding:.35rem .9rem;font-weight:bold;cursor:pointer}
 .card ul{list-style:circle;margin-top:.4rem;text-align:left;padding-left:1.1rem;font-size:.85rem}
-.gold{color:#ffd700;font-size:1.2rem;margin-right:4px}
+.gold{color:var(--sg);font-size:1.2rem;margin-right:4px}
 
 /* ========= Contacto ========= */
 @font-face{font-family:'SevenSeg';src:url('https://fonts.cdnfonts.com/s/17464/Digital7-1.woff') format('woff')}


### PR DESCRIPTION
## Summary
- Add Cinzel font and chalkboard color palette
- Introduce speed slider and difficulty-scaled problems for bomb math game
- Revamp course cards with icons, 20-topic temarios and scheduling form
- Show notification bubble when pending messages exist

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_689523ba12c08325b540a1ef842acd7c