### PR TITLE
Prefill WhatsApp messages and enhance “Publica tu producto” visuals

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -148,7 +148,8 @@ a:focus-visible {
 }
 
 .contact-info strong {
-  font-size: 1.2rem;
+  font-size: 1.45rem;
+  font-weight: 700;
 }
 
 .btn {
@@ -452,6 +453,11 @@ a:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+}
+
+.footer-contact strong {
+  font-size: 1.35rem;
+  font-weight: 700;
 }
 
 .toast {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
           <span>WhatsApp directo</span>
           <strong>+52 56 1088 5357</strong>
         </div>
-        <a class="btn btn-whatsapp" id="topWhatsapp" href="https://wa.me/525610885357" target="_blank" rel="noopener">Contactar</a>
+        <a class="btn btn-whatsapp" id="topWhatsapp" data-whatsapp-message="Hola Alberto. Quiero información sobre cursos y productos en LA TIENDA DE ALBERTO." href="https://wa.me/525610885357" target="_blank" rel="noopener">Contactar</a>
       </div>
     </div>
   </header>
@@ -128,13 +128,17 @@
             <button class="btn btn-ghost" type="button">Subir imagen</button>
             <p class="muted small">Para publicar o editar productos se requiere acceso (solo administrador).</p>
           </div>
-          <div class="publica-info">
-            <h3>¿Qué se necesita?</h3>
-            <ul>
-              <li>Imagen clara del producto</li>
-              <li>Descripción breve</li>
-              <li>Precio en MXN</li>
-            </ul>
+          <div class="publica-info card">
+            <h3>Detalles sugeridos</h3>
+            <label class="field">
+              <span>Mini-descripción</span>
+              <textarea rows="3" placeholder="Ej. Calculadora científica en excelente estado" disabled></textarea>
+            </label>
+            <label class="field">
+              <span>Precio MXN</span>
+              <input type="text" placeholder="$350 MXN" disabled>
+            </label>
+            <p class="muted small">Esta sección es informativa. La publicación real se gestiona desde el panel admin.</p>
           </div>
         </div>
       </div>
@@ -244,7 +248,7 @@
                 <p><strong>WhatsApp:</strong> +52 56 1088 5357</p>
                 <p><strong>Horario:</strong> Lunes a sábado, 9:00 - 19:00</p>
                 <p><strong>Ubicación:</strong> Ciudad de México</p>
-                <a class="btn btn-whatsapp" id="contactWhatsapp" href="https://wa.me/525610885357" target="_blank" rel="noopener">Contactar por WhatsApp</a>
+                <a class="btn btn-whatsapp" id="contactWhatsapp" data-whatsapp-message="Hola Alberto. Me gustaría recibir información y asesoría." href="https://wa.me/525610885357" target="_blank" rel="noopener">Contactar por WhatsApp</a>
               </div>
             </div>
           </div>
@@ -262,7 +266,7 @@
       <div class="footer-contact">
         <span>WhatsApp</span>
         <strong>+52 56 1088 5357</strong>
-        <a class="btn btn-whatsapp" id="bottomWhatsapp" href="https://wa.me/525610885357" target="_blank" rel="noopener">Contactar</a>
+        <a class="btn btn-whatsapp" id="bottomWhatsapp" data-whatsapp-message="Hola Alberto. Quiero información sobre cursos y productos en LA TIENDA DE ALBERTO." href="https://wa.me/525610885357" target="_blank" rel="noopener">Contactar</a>
       </div>
     </div>
   </footer>

--- a/js/main.js
+++ b/js/main.js
@@ -16,6 +16,7 @@ const sortSelect = document.getElementById("sortSelect");
 const notificationToast = document.getElementById("notificationToast");
 const notificationMessage = document.getElementById("notificationMessage");
 const closeNotification = document.getElementById("closeNotification");
+const staticWhatsAppLinks = document.querySelectorAll("[data-whatsapp-message]");
 
 const adminModal = document.getElementById("adminModal");
 const openAdmin = document.getElementById("openAdmin");
@@ -91,6 +92,15 @@ const currencyFormatter = new Intl.NumberFormat("es-MX", {
 
 const createWhatsAppUrl = (message) =>
   `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(message)}`;
+
+const setupStaticWhatsAppLinks = () => {
+  staticWhatsAppLinks.forEach((link) => {
+    const message = link.dataset.whatsappMessage;
+    if (message) {
+      link.href = createWhatsAppUrl(message);
+    }
+  });
+};
 
 const parsePrice = (value) => {
   if (!value) return null;
@@ -730,6 +740,7 @@ const init = () => {
   renderProducts();
   updateAdminList();
   setupCourseButtons();
+  setupStaticWhatsAppLinks();
   setupTabs();
   setupAdminTabs();
   setupNotification();


### PR DESCRIPTION
### Motivation

- Make the main contact buttons open WhatsApp with context-aware, prefilled messages to reduce friction for users contacting Alberto.
- Provide a clearer, more informative visual for the “Publica tu producto” area so visitors know what to prepare before asking for admin access.
- Increase the visibility of the WhatsApp number in header/footer to improve conversion on mobile and desktop.

### Description

- Added `data-whatsapp-message` attributes to the top, contact card and footer WhatsApp buttons and wired them to a new `setupStaticWhatsAppLinks` function in `js/main.js` which sets the `href` using `createWhatsAppUrl`.
- Replaced the simple informational block in the `Publica tu producto` section with a card containing disabled input controls to show suggested `Mini-descripción` and `Precio MXN` examples in `index.html`.
- Increased font-size and weight for the WhatsApp number in the header and footer via updates in `css/base.css` to improve visibility.
- Minor adjustments to JS initialization to call `setupStaticWhatsAppLinks` during `init` so the static links are updated on load.

### Testing

- Started a local static server with `python -m http.server 8000` and the server started successfully.
- Ran an automated Playwright script that opened `http://127.0.0.1:8000/index.html`, waited for idle, and captured a full-page screenshot which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6ad24ad083258efd0f5b2b3bae09)