### PR TITLE
Add LA TIENDA DE ALBERTO static site with catalog, proposals and admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# fisurasmatematicas
-Código fuente de mi página educativa.
+# LA TIENDA DE ALBERTO
 
-## Cursos
-Los cursos se definen en `data/courses.json` con campos de fechas, horarios y 20 temas por materia. Edita ese archivo para actualizar temarios o fechas.
-La página `courses.html` permite ver el catálogo, inscribirse y agendar llamadas. Las inscripciones se guardan en `data/enrollments.json` y las agendas en `data/callbacks.json`. Las notificaciones se manejan en `data/notifications.json` y se muestran como insignia en el enlace de acceso.
+Subir el contenido del ZIP directo a /htdocs. El index.html debe quedar en /htdocs/.

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,613 @@
+:root {
+  color-scheme: light;
+  --bg: #071127;
+  --bg-alt: #0e1c3a;
+  --card: #ffffff;
+  --text: #0d1224;
+  --muted: #5b657a;
+  --accent: #f0c75e;
+  --cta: #1dbba7;
+  --cta-dark: #129483;
+  --border: rgba(13, 18, 36, 0.12);
+  --shadow: 0 20px 40px rgba(6, 18, 40, 0.12);
+  --radius: 18px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: #f5f7fb;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+a:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 0;
+  background: var(--accent);
+  color: #1a1a1a;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+}
+
+.container {
+  width: min(1150px, 92%);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--bg);
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(4, 10, 26, 0.4);
+}
+
+.header-grid {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1.5rem 0;
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2.5vw, 2.3rem);
+}
+
+.brand-kicker {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+}
+
+.main-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-weight: 600;
+}
+
+.main-nav a {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.main-nav a:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.admin-button {
+  background: transparent;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.contact-bar {
+  background: var(--bg-alt);
+  padding: 0.75rem 0;
+}
+
+.contact-bar-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.contact-info {
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+}
+
+.contact-info strong {
+  font-size: 1.2rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn-primary {
+  background: var(--cta);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(29, 187, 167, 0.35);
+}
+
+.btn-primary:hover {
+  background: var(--cta-dark);
+}
+
+.btn-ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.btn-whatsapp {
+  background: #1f8c75;
+  color: #fff;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.hero {
+  background: radial-gradient(circle at top, #18274d, var(--bg));
+  color: #fff;
+  padding: 4rem 0;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: center;
+}
+
+.eyebrow {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+}
+
+.lead {
+  font-size: 1.1rem;
+  margin-bottom: 1.5rem;
+}
+
+.hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.hero-card {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 2rem;
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.hero-card ul {
+  margin: 1rem 0 0;
+  padding-left: 1rem;
+}
+
+.trust-box {
+  background: rgba(255, 255, 255, 0.12);
+  padding: 1.25rem;
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.section {
+  padding: 4rem 0;
+}
+
+.alt-section {
+  background: #f0f3fb;
+}
+
+.section-head {
+  margin-bottom: 2rem;
+}
+
+.section-head h2 {
+  margin: 0 0 0.5rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.card {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(13, 18, 36, 0.05);
+}
+
+.course-card .price {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0.75rem 0 1rem;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 1 1 200px;
+  font-weight: 600;
+}
+
+.field input,
+.field textarea,
+.field select {
+  padding: 0.6rem 0.8rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #fff;
+}
+
+.muted {
+  color: var(--muted);
+  margin: 0.4rem 0 0;
+}
+
+.small {
+  font-size: 0.85rem;
+}
+
+.product-card img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  border-radius: 14px;
+  margin-bottom: 1rem;
+}
+
+.steps-grid,
+.trust-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.step-card {
+  background: #fff;
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+}
+
+.product-card .price {
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.publica-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.dropzone .preview {
+  margin-top: 1rem;
+  border-radius: 12px;
+  max-height: 200px;
+  object-fit: cover;
+}
+
+.proposal-status {
+  margin-top: 0.75rem;
+}
+
+.dropzone {
+  border: 2px dashed var(--border);
+  border-radius: var(--radius);
+  padding: 2rem;
+  text-align: center;
+  background: #fff;
+}
+
+.dropzone.is-dragging {
+  border-color: var(--cta);
+  background: #eefbf8;
+}
+
+.dropzone img {
+  margin: 1rem auto 0;
+  max-height: 180px;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+.tabs {
+  background: #fff;
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.tab-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.tab {
+  background: #f0f3fb;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.tab[aria-selected="true"] {
+  background: var(--cta);
+  color: #fff;
+}
+
+.panel-grid,
+.student-grid,
+.contact-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.game-area {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.game-question {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.timeline li {
+  background: #f7f9ff;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.field-row {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.preview-box {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 12px;
+  background: #f7f9ff;
+}
+
+.site-footer {
+  background: var(--bg);
+  color: #fff;
+  padding: 2rem 0;
+}
+
+.footer-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.footer-contact {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  background: #fff;
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  max-width: 320px;
+  z-index: 200;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 8, 20, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 300;
+}
+
+.modal.show {
+  display: flex;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: var(--radius);
+  padding: 2rem;
+  width: min(900px, 95vw);
+  max-height: 90vh;
+  overflow: auto;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  border: none;
+  background: #f0f3fb;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+  font-size: 1.5rem;
+}
+
+.admin-list {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.admin-item {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 80px 1fr auto;
+  align-items: center;
+  background: #f7f9ff;
+  padding: 1rem;
+  border-radius: 14px;
+}
+
+.admin-item img {
+  width: 80px;
+  height: 80px;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+.admin-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .header-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .main-nav {
+    justify-content: center;
+  }
+
+  .contact-bar-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 3rem 0;
+  }
+
+  .contact-info strong {
+    font-size: 1.1rem;
+  }
+
+  .admin-item {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LA TIENDA DE ALBERTO</title>
-  <link rel="stylesheet" href="css/base.css">
+  <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -16,10 +16,11 @@
       </div>
       <nav class="main-nav" aria-label="Principal">
         <a href="#inicio">Inicio</a>
+        <a href="#como-funciona">Cómo funciona</a>
         <a href="#cursos">Cursos</a>
-        <a href="#productos">Productos</a>
-        <a href="#interactivo">Juego & Estudiantes</a>
-        <a href="#publica">Publica tu producto</a>
+        <a href="#catalogo">Catálogo</a>
+        <a href="#propuestas">Propón tu producto</a>
+        <a href="#interactivo">Zona interactiva</a>
       </nav>
       <button class="admin-button" id="openAdmin" type="button">Admin</button>
     </div>
@@ -29,7 +30,7 @@
           <span>WhatsApp directo</span>
           <strong>+52 56 1088 5357</strong>
         </div>
-        <a class="btn btn-whatsapp" id="topWhatsapp" href="https://wa.me/525610885357" target="_blank" rel="noopener">Contactar</a>
+        <a class="btn btn-whatsapp" id="topWhatsapp" href="https://wa.me/525610885357?text=Hola%20Alberto,%20quiero%20informaci%C3%B3n%20por%20favor." target="_blank" rel="noopener">Contactar</a>
       </div>
     </div>
   </header>
@@ -43,11 +44,11 @@
           <p class="lead">Cursos intensivos y catálogo verificado. Comunicación directa por WhatsApp con procesos claros.</p>
           <div class="hero-cta">
             <a class="btn btn-primary" href="#cursos">Ver cursos</a>
-            <a class="btn btn-ghost" href="#productos">Explorar productos</a>
+            <a class="btn btn-ghost" href="#catalogo">Explorar catálogo</a>
           </div>
           <div class="trust-box">
             <p><strong>Comisión: 20% por venta</strong></p>
-            <p class="muted">El vendedor conserva sus productos. Después de acordar pago, comprador y vendedor coordinan día/hora de entrega. Alberto ya no interviene en esa coordinación.</p>
+            <p class="muted">El vendedor conserva su producto. Tras el pago, comprador y vendedor acuerdan día y hora de entrega directamente; Alberto no interviene en esa coordinación.</p>
           </div>
         </div>
         <div class="hero-card">
@@ -58,6 +59,52 @@
             <li>Pago seguro por acuerdo directo</li>
             <li>Soporte personalizado</li>
           </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="como-funciona" class="section">
+      <div class="container">
+        <div class="section-head">
+          <h2>Cómo funciona</h2>
+          <p>Proceso claro para colaboradores y compradores.</p>
+        </div>
+        <div class="steps-grid">
+          <article class="step-card">
+            <h3>1. Propón tu producto</h3>
+            <p>Envía imagen, descripción y precio. Tu propuesta queda en revisión.</p>
+          </article>
+          <article class="step-card">
+            <h3>2. Se revisa y aprueba</h3>
+            <p>Al aprobarse, el producto aparece en el catálogo público.</p>
+          </article>
+          <article class="step-card">
+            <h3>3. Compradores contactan</h3>
+            <p>Los interesados te escriben por WhatsApp para cerrar la venta.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="confianza" class="section alt-section">
+      <div class="container">
+        <div class="section-head">
+          <h2>Confianza y transparencia</h2>
+          <p>Comisión clara y coordinación directa para entregas.</p>
+        </div>
+        <div class="trust-grid">
+          <article class="card">
+            <h3>Comisión visible</h3>
+            <p>La comisión de 20% por venta está clara desde el inicio, sin costos ocultos.</p>
+          </article>
+          <article class="card">
+            <h3>Entrega coordinada</h3>
+            <p>Después del pago, comprador y vendedor coordinan día y hora directamente.</p>
+          </article>
+          <article class="card">
+            <h3>Catálogo curado</h3>
+            <p>Solo se publican productos aprobados por el administrador.</p>
+          </article>
         </div>
       </div>
     </section>
@@ -91,11 +138,11 @@
       </div>
     </section>
 
-    <section id="productos" class="section alt-section">
+    <section id="catalogo" class="section alt-section">
       <div class="container">
         <div class="section-head">
-          <h2>Productos</h2>
-          <p>Catálogo actualizado con productos y servicios disponibles.</p>
+          <h2>Catálogo</h2>
+          <p>Productos y servicios aprobados, listos para comprar.</p>
         </div>
         <div class="filters">
           <label class="field">
@@ -115,25 +162,42 @@
       </div>
     </section>
 
-    <section id="publica" class="section">
+    <section id="propuestas" class="section">
       <div class="container">
         <div class="section-head">
-          <h2>Publica tu producto</h2>
-          <p>Comparte tu producto con nuestra comunidad. La publicación se gestiona desde el panel administrador.</p>
+          <h2>Propón tu producto o servicio</h2>
+          <p>Envía tu propuesta y se revisa para aprobación. Solo el administrador publica.</p>
         </div>
         <div class="publica-grid">
-          <div class="dropzone" aria-label="Zona de carga de imagen">
-            <p><strong>Arrastrar y soltar imagen</strong></p>
-            <p class="muted">o</p>
-            <button class="btn btn-ghost" type="button">Subir imagen</button>
-            <p class="muted small">Para publicar o editar productos se requiere acceso (solo administrador).</p>
-          </div>
+          <form id="proposalForm" class="card form-grid">
+            <div class="dropzone" id="proposalDropzone">
+              <p><strong>Arrastra y suelta tu imagen</strong></p>
+              <p class="muted">o</p>
+              <input type="file" id="proposalImage" accept="image/*" hidden>
+              <button class="btn btn-ghost" id="proposalImageBtn" type="button">Subir imagen</button>
+              <img class="preview" id="proposalPreview" alt="Vista previa" hidden>
+            </div>
+            <label class="field">
+              <span>Título</span>
+              <input type="text" id="proposalTitle" required>
+            </label>
+            <label class="field">
+              <span>Mini-descripción (máx 220)</span>
+              <textarea id="proposalDescription" maxlength="220" rows="3" required></textarea>
+            </label>
+            <label class="field">
+              <span>Precio MXN</span>
+              <input type="text" id="proposalPrice" placeholder="350.50" required>
+            </label>
+            <button class="btn btn-primary" type="submit">Enviar propuesta</button>
+            <p id="proposalStatus" class="muted proposal-status" aria-live="polite"></p>
+          </form>
           <div class="publica-info">
-            <h3>¿Qué se necesita?</h3>
+            <h3>¿Qué sucede después?</h3>
             <ul>
-              <li>Imagen clara del producto</li>
-              <li>Descripción breve</li>
-              <li>Precio en MXN</li>
+              <li>Tu propuesta queda en revisión</li>
+              <li>Recibirás confirmación al aprobarse</li>
+              <li>La comisión es del 20% por venta</li>
             </ul>
           </div>
         </div>
@@ -244,7 +308,7 @@
                 <p><strong>WhatsApp:</strong> +52 56 1088 5357</p>
                 <p><strong>Horario:</strong> Lunes a sábado, 9:00 - 19:00</p>
                 <p><strong>Ubicación:</strong> Ciudad de México</p>
-                <a class="btn btn-whatsapp" id="contactWhatsapp" href="https://wa.me/525610885357" target="_blank" rel="noopener">Contactar por WhatsApp</a>
+                <a class="btn btn-whatsapp" id="contactWhatsapp" href="https://wa.me/525610885357?text=Hola%20Alberto,%20quiero%20informaci%C3%B3n%20por%20favor." target="_blank" rel="noopener">Contactar por WhatsApp</a>
               </div>
             </div>
           </div>
@@ -258,11 +322,12 @@
       <div>
         <h3>LA TIENDA DE ALBERTO</h3>
         <p class="muted">Cursos, productos y asesoría directa.</p>
+        <p class="muted"><strong>Comisión: 20% por venta.</strong> Coordinación directa entre comprador y vendedor.</p>
       </div>
       <div class="footer-contact">
         <span>WhatsApp</span>
         <strong>+52 56 1088 5357</strong>
-        <a class="btn btn-whatsapp" id="bottomWhatsapp" href="https://wa.me/525610885357" target="_blank" rel="noopener">Contactar</a>
+        <a class="btn btn-whatsapp" id="bottomWhatsapp" href="https://wa.me/525610885357?text=Hola%20Alberto,%20quiero%20informaci%C3%B3n%20por%20favor." target="_blank" rel="noopener">Contactar</a>
       </div>
     </div>
   </footer>
@@ -293,14 +358,20 @@
       <div id="adminPanel" hidden>
         <div class="panel-header">
           <div class="tab-list" role="tablist" aria-label="Panel administrador">
-            <button class="tab" role="tab" aria-selected="true" aria-controls="admin-products" id="admin-products-btn">Productos</button>
+            <button class="tab" role="tab" aria-selected="true" aria-controls="admin-pending" id="admin-pending-btn">Pendientes</button>
+            <button class="tab" role="tab" aria-selected="false" aria-controls="admin-products" id="admin-products-btn">Productos</button>
             <button class="tab" role="tab" aria-selected="false" aria-controls="admin-notifications" id="admin-notifications-btn">Notificaciones</button>
             <button class="tab" role="tab" aria-selected="false" aria-controls="admin-settings" id="admin-settings-btn">Ajustes</button>
           </div>
           <button class="btn btn-ghost" id="adminLogout" type="button">Cerrar sesión</button>
         </div>
 
-        <div id="admin-products" class="tab-panel" role="tabpanel" aria-labelledby="admin-products-btn">
+        <div id="admin-pending" class="tab-panel" role="tabpanel" aria-labelledby="admin-pending-btn">
+          <p class="muted">Revisa propuestas y aprueba solo las que cumplan con calidad y comisión del 20%.</p>
+          <div id="adminPendingList" class="admin-list"></div>
+        </div>
+
+        <div id="admin-products" class="tab-panel" role="tabpanel" aria-labelledby="admin-products-btn" hidden>
           <div class="admin-actions">
             <button class="btn btn-primary" id="newProduct" type="button">Nuevo producto</button>
             <p class="muted" id="adminStorageStatus"></p>
@@ -355,7 +426,7 @@
         <div id="admin-settings" class="tab-panel" role="tabpanel" aria-labelledby="admin-settings-btn" hidden>
           <div class="card">
             <h3>Respaldo</h3>
-            <p class="muted">Exporta o importa tu catálogo y notificaciones.</p>
+            <p class="muted">Exporta o importa tu catálogo, pendientes y notificaciones.</p>
             <div class="form-actions">
               <button class="btn btn-primary" id="exportData" type="button">Exportar JSON</button>
               <input type="file" id="importData" accept="application/json" hidden>
@@ -368,6 +439,6 @@
     </div>
   </div>
 
-  <script src="js/main.js"></script>
+  <script src="js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,998 @@
+const WHATSAPP_NUMBER = "525610885357";
+const APPROVED_KEY = "LTA_APPROVED_V1";
+const PENDING_KEY = "LTA_PENDING_V1";
+const NOTIFICATION_TEXT_KEY = "LTA_NOTIFICATION_TEXT_V1";
+const NOTIFICATION_ENABLED_KEY = "LTA_NOTIFICATION_ENABLED_V1";
+const ADMIN_SESSION_KEY = "LTA_ADMIN_SESSION_V1";
+const STUDENT_SESSION_KEY = "LTA_STUDENT_SESSION_V1";
+const STUDENT_CONTENT_KEY = "LTA_STUDENT_CONTENT_V1";
+
+const DEFAULT_NOTIFICATION =
+  "Bienvenido a LA TIENDA DE ALBERTO. Consulta cursos y productos disponibles.";
+
+const courseButtons = document.querySelectorAll("[data-course]");
+const productGrid = document.getElementById("productGrid");
+const searchInput = document.getElementById("searchInput");
+const sortSelect = document.getElementById("sortSelect");
+const notificationToast = document.getElementById("notificationToast");
+const notificationMessage = document.getElementById("notificationMessage");
+const closeNotification = document.getElementById("closeNotification");
+
+const proposalForm = document.getElementById("proposalForm");
+const proposalDropzone = document.getElementById("proposalDropzone");
+const proposalImageBtn = document.getElementById("proposalImageBtn");
+const proposalImage = document.getElementById("proposalImage");
+const proposalPreview = document.getElementById("proposalPreview");
+const proposalTitle = document.getElementById("proposalTitle");
+const proposalDescription = document.getElementById("proposalDescription");
+const proposalPrice = document.getElementById("proposalPrice");
+const proposalStatus = document.getElementById("proposalStatus");
+
+const adminModal = document.getElementById("adminModal");
+const openAdmin = document.getElementById("openAdmin");
+const closeAdmin = document.getElementById("closeAdmin");
+const adminLogin = document.getElementById("adminLogin");
+const adminPanel = document.getElementById("adminPanel");
+const adminLoginForm = document.getElementById("adminLoginForm");
+const adminPassword = document.getElementById("adminPassword");
+const adminLoginStatus = document.getElementById("adminLoginStatus");
+const adminLogout = document.getElementById("adminLogout");
+
+const adminPendingList = document.getElementById("adminPendingList");
+const adminProductList = document.getElementById("adminProductList");
+const newProductBtn = document.getElementById("newProduct");
+const productForm = document.getElementById("productForm");
+const productFormTitle = document.getElementById("productFormTitle");
+const productImage = document.getElementById("productImage");
+const productImageBtn = document.getElementById("productImageBtn");
+const productPreview = document.getElementById("productPreview");
+const adminDropzone = document.getElementById("adminDropzone");
+const adminWhatsApp = document.getElementById("adminWhatsApp");
+const productTitle = document.getElementById("productTitle");
+const productDescription = document.getElementById("productDescription");
+const productPrice = document.getElementById("productPrice");
+const descCount = document.getElementById("descCount");
+const cancelProduct = document.getElementById("cancelProduct");
+const productFormStatus = document.getElementById("productFormStatus");
+const adminStorageStatus = document.getElementById("adminStorageStatus");
+
+const notificationForm = document.getElementById("notificationForm");
+const notificationInput = document.getElementById("notificationInput");
+const notificationEnabled = document.getElementById("notificationEnabled");
+const notificationStatus = document.getElementById("notificationStatus");
+
+const exportDataBtn = document.getElementById("exportData");
+const importDataBtn = document.getElementById("importDataBtn");
+const importDataInput = document.getElementById("importData");
+const settingsStatus = document.getElementById("settingsStatus");
+
+const tabButtons = document.querySelectorAll("[data-tabs] .tab");
+const adminTabButtons = document.querySelectorAll("#adminPanel .tab");
+
+const gameQuestion = document.getElementById("gameQuestion");
+const gameAnswer = document.getElementById("gameAnswer");
+const gameSubmit = document.getElementById("gameSubmit");
+const gameReset = document.getElementById("gameReset");
+const gameFeedback = document.getElementById("gameFeedback");
+
+const studentLoginForm = document.getElementById("studentLoginForm");
+const studentPassword = document.getElementById("studentPassword");
+const studentLoginStatus = document.getElementById("studentLoginStatus");
+const studentPanel = document.getElementById("studentPanel");
+const studentLogout = document.getElementById("studentLogout");
+const studentEditForm = document.getElementById("studentEditForm");
+const studentContent = document.getElementById("studentContent");
+const studentDate = document.getElementById("studentDate");
+const studentNumber = document.getElementById("studentNumber");
+const studentSaveStatus = document.getElementById("studentSaveStatus");
+const studentPreview = document.getElementById("studentPreview");
+
+const contactForm = document.getElementById("contactForm");
+const contactStatus = document.getElementById("contactStatus");
+
+let approvedProducts = [];
+let pendingProposals = [];
+let editingApprovedId = null;
+let editingPendingId = null;
+let editingMode = "approved";
+let currentGame = null;
+
+const currencyFormatter = new Intl.NumberFormat("es-MX", {
+  style: "currency",
+  currency: "MXN",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+});
+
+const createWhatsAppUrl = (message) =>
+  `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(message)}`;
+
+const parsePrice = (value) => {
+  if (!value) return null;
+  const normalized = value.toString().trim().replace(",", ".");
+  const numberValue = Number.parseFloat(normalized);
+  return Number.isFinite(numberValue) ? numberValue : null;
+};
+
+const formatPrice = (value) => currencyFormatter.format(value ?? 0);
+
+const safeText = (value) => (value ?? "").toString();
+
+const generateId = () =>
+  typeof crypto !== "undefined" && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `prod-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+
+const demoImage = (label) => {
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+      <defs>
+        <linearGradient id="a" x1="0" x2="1" y1="0" y2="1">
+          <stop offset="0" stop-color="#1dbba7"/>
+          <stop offset="1" stop-color="#f0c75e"/>
+        </linearGradient>
+      </defs>
+      <rect width="600" height="400" fill="url(#a)"/>
+      <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Arial" font-size="34" fill="#ffffff">${label}</text>
+    </svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+};
+
+const defaultProducts = () => [
+  {
+    id: generateId(),
+    title: "Calculadora científica",
+    description: "Ideal para bachillerato y primeros semestres. Incluye manual.",
+    price: 650,
+    imageDataUrl: demoImage("Calculadora"),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  },
+  {
+    id: generateId(),
+    title: "Asesoría personalizada",
+    description: "Sesión 1 a 1 para resolver dudas y reforzar conceptos.",
+    price: 450,
+    imageDataUrl: demoImage("Asesoría"),
+    createdAt: Date.now() - 10000,
+    updatedAt: Date.now() - 10000,
+  },
+  {
+    id: generateId(),
+    title: "Guía de ejercicios",
+    description: "Colección de problemas con soluciones paso a paso.",
+    price: 220,
+    imageDataUrl: demoImage("Guía"),
+    createdAt: Date.now() - 20000,
+    updatedAt: Date.now() - 20000,
+  },
+];
+
+const saveToStorage = (key, value) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+const loadFromStorage = (key, fallback) => {
+  const raw = localStorage.getItem(key);
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    return fallback;
+  }
+};
+
+const loadApproved = () => {
+  const stored = loadFromStorage(APPROVED_KEY, null);
+  if (stored && Array.isArray(stored)) {
+    approvedProducts = stored;
+    return;
+  }
+  approvedProducts = defaultProducts();
+  saveToStorage(APPROVED_KEY, approvedProducts);
+};
+
+const loadPending = () => {
+  const stored = loadFromStorage(PENDING_KEY, []);
+  pendingProposals = Array.isArray(stored) ? stored : [];
+};
+
+const renderProducts = () => {
+  const query = safeText(searchInput.value).toLowerCase();
+  const sort = sortSelect.value;
+
+  let filtered = approvedProducts.filter((product) => {
+    const text = `${product.title} ${product.description}`.toLowerCase();
+    return text.includes(query);
+  });
+
+  if (sort === "price-asc") {
+    filtered.sort((a, b) => a.price - b.price);
+  } else if (sort === "price-desc") {
+    filtered.sort((a, b) => b.price - a.price);
+  } else {
+    filtered.sort((a, b) => b.createdAt - a.createdAt);
+  }
+
+  productGrid.innerHTML = "";
+  filtered.forEach((product) => {
+    const card = document.createElement("article");
+    card.className = "card product-card";
+
+    const img = document.createElement("img");
+    img.loading = "lazy";
+    img.src = product.imageDataUrl;
+    img.alt = safeText(product.title);
+
+    const title = document.createElement("h3");
+    title.textContent = safeText(product.title);
+
+    const desc = document.createElement("p");
+    desc.textContent = safeText(product.description);
+
+    const price = document.createElement("p");
+    price.className = "price";
+    price.textContent = formatPrice(product.price);
+
+    const button = document.createElement("a");
+    button.className = "btn btn-whatsapp";
+    button.target = "_blank";
+    button.rel = "noopener";
+    button.textContent = "Comprar por WhatsApp";
+    const message = `Hola Alberto. Me interesa este producto: ${product.title}. Precio: $${product.price} MXN. ¿Sigue disponible? ¿Cómo procedemos?`;
+    button.href = createWhatsAppUrl(message);
+
+    card.append(img, title, desc, price, button);
+    productGrid.appendChild(card);
+  });
+};
+
+const updateAdminList = () => {
+  adminProductList.innerHTML = "";
+  if (!approvedProducts.length) {
+    const empty = document.createElement("p");
+    empty.className = "muted";
+    empty.textContent = "No hay productos aprobados aún.";
+    adminProductList.appendChild(empty);
+    return;
+  }
+
+  approvedProducts.forEach((product) => {
+    const item = document.createElement("div");
+    item.className = "admin-item";
+
+    const img = document.createElement("img");
+    img.src = product.imageDataUrl;
+    img.alt = safeText(product.title);
+
+    const info = document.createElement("div");
+    const title = document.createElement("strong");
+    title.textContent = safeText(product.title);
+    const meta = document.createElement("p");
+    meta.className = "muted";
+    meta.textContent = `${formatPrice(product.price)} · ${safeText(product.description)}`;
+    info.append(title, meta);
+
+    const actions = document.createElement("div");
+    const editBtn = document.createElement("button");
+    editBtn.className = "btn btn-ghost";
+    editBtn.type = "button";
+    editBtn.textContent = "Editar";
+    editBtn.addEventListener("click", () => openEditForm(product, "approved"));
+
+    const deleteBtn = document.createElement("button");
+    deleteBtn.className = "btn btn-ghost";
+    deleteBtn.type = "button";
+    deleteBtn.textContent = "Borrar";
+    deleteBtn.addEventListener("click", () => deleteProduct(product.id));
+
+    actions.append(editBtn, deleteBtn);
+    item.append(img, info, actions);
+    adminProductList.appendChild(item);
+  });
+};
+
+const updatePendingList = () => {
+  adminPendingList.innerHTML = "";
+  if (!pendingProposals.length) {
+    const empty = document.createElement("p");
+    empty.className = "muted";
+    empty.textContent = "No hay propuestas pendientes.";
+    adminPendingList.appendChild(empty);
+    return;
+  }
+
+  pendingProposals.forEach((proposal) => {
+    const item = document.createElement("div");
+    item.className = "admin-item";
+
+    const img = document.createElement("img");
+    img.src = proposal.imageDataUrl;
+    img.alt = safeText(proposal.title);
+
+    const info = document.createElement("div");
+    const title = document.createElement("strong");
+    title.textContent = safeText(proposal.title);
+    const meta = document.createElement("p");
+    meta.className = "muted";
+    meta.textContent = `${formatPrice(proposal.price)} · ${safeText(proposal.description)}`;
+    info.append(title, meta);
+
+    const actions = document.createElement("div");
+    const approveBtn = document.createElement("button");
+    approveBtn.className = "btn btn-primary";
+    approveBtn.type = "button";
+    approveBtn.textContent = "Aprobar";
+    approveBtn.addEventListener("click", () => approveProposal(proposal.id));
+
+    const editBtn = document.createElement("button");
+    editBtn.className = "btn btn-ghost";
+    editBtn.type = "button";
+    editBtn.textContent = "Editar antes de aprobar";
+    editBtn.addEventListener("click", () => openEditForm(proposal, "pending"));
+
+    const rejectBtn = document.createElement("button");
+    rejectBtn.className = "btn btn-ghost";
+    rejectBtn.type = "button";
+    rejectBtn.textContent = "Rechazar";
+    rejectBtn.addEventListener("click", () => rejectProposal(proposal.id));
+
+    actions.append(approveBtn, editBtn, rejectBtn);
+    item.append(img, info, actions);
+    adminPendingList.appendChild(item);
+  });
+};
+
+const resetProductForm = () => {
+  productForm.reset();
+  productPreview.hidden = true;
+  productPreview.src = "";
+  productPreview.dataset.image = "";
+  editingApprovedId = null;
+  editingPendingId = null;
+  editingMode = "approved";
+  productFormTitle.textContent = "Nuevo producto";
+  productFormStatus.textContent = "";
+  descCount.textContent = "0/220";
+};
+
+const openEditForm = (item, mode) => {
+  productForm.hidden = false;
+  editingMode = mode;
+  if (mode === "approved") {
+    productFormTitle.textContent = "Editar producto";
+    editingApprovedId = item.id;
+    editingPendingId = null;
+  } else {
+    productFormTitle.textContent = "Editar propuesta pendiente";
+    editingPendingId = item.id;
+    editingApprovedId = null;
+  }
+  productTitle.value = item.title;
+  productDescription.value = item.description;
+  productPrice.value = item.price;
+  descCount.textContent = `${item.description.length}/220`;
+  productPreview.src = item.imageDataUrl;
+  productPreview.dataset.image = item.imageDataUrl;
+  productPreview.hidden = false;
+
+  const adminProductsTab = document.getElementById("admin-products-btn");
+  if (adminProductsTab) adminProductsTab.click();
+};
+
+const deleteProduct = (id) => {
+  const confirmed = window.confirm("¿Seguro que deseas borrar este producto?");
+  if (!confirmed) return;
+  approvedProducts = approvedProducts.filter((product) => product.id !== id);
+  persistApproved();
+};
+
+const approveProposal = (id) => {
+  const proposal = pendingProposals.find((item) => item.id === id);
+  if (!proposal) return;
+  const confirmed = window.confirm(
+    "¿Aprobar esta propuesta y publicarla en el catálogo?"
+  );
+  if (!confirmed) return;
+  pendingProposals = pendingProposals.filter((item) => item.id !== id);
+  approvedProducts.unshift({
+    ...proposal,
+    updatedAt: Date.now(),
+  });
+  persistPending();
+  persistApproved();
+};
+
+const rejectProposal = (id) => {
+  const confirmed = window.confirm("¿Rechazar esta propuesta?");
+  if (!confirmed) return;
+  pendingProposals = pendingProposals.filter((item) => item.id !== id);
+  persistPending();
+};
+
+const persistApproved = () => {
+  const saved = saveToStorage(APPROVED_KEY, approvedProducts);
+  if (!saved) {
+    adminStorageStatus.textContent =
+      "No se pudo guardar. Reduce el tamaño de la imagen o elimina productos.";
+    return;
+  }
+  adminStorageStatus.textContent = "";
+  renderProducts();
+  updateAdminList();
+};
+
+const persistPending = () => {
+  const saved = saveToStorage(PENDING_KEY, pendingProposals);
+  if (!saved) {
+    adminStorageStatus.textContent =
+      "No se pudo guardar pendientes. Reduce el tamaño de las imágenes.";
+  }
+  updatePendingList();
+};
+
+const compressImage = (file) =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const maxWidth = 1200;
+        const scale = Math.min(1, maxWidth / img.width);
+        const canvas = document.createElement("canvas");
+        canvas.width = img.width * scale;
+        canvas.height = img.height * scale;
+        const ctx = canvas.getContext("2d");
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        const dataUrl = canvas.toDataURL("image/jpeg", 0.75);
+        resolve(dataUrl);
+      };
+      img.onerror = () => reject(new Error("Imagen inválida"));
+      img.src = reader.result;
+    };
+    reader.onerror = () => reject(new Error("No se pudo leer la imagen"));
+    reader.readAsDataURL(file);
+  });
+
+const handleImageDrop = async ({ file, previewEl, statusEl }) => {
+  if (!file) return;
+  try {
+    const dataUrl = await compressImage(file);
+    previewEl.src = dataUrl;
+    previewEl.hidden = false;
+    previewEl.dataset.image = dataUrl;
+    if (statusEl) statusEl.textContent = "";
+  } catch (error) {
+    if (statusEl) {
+      statusEl.textContent = "No se pudo procesar la imagen.";
+    }
+  }
+};
+
+const setupCourseButtons = () => {
+  courseButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const course = button.dataset.course;
+      const message = `Hola Alberto. Quiero inscribirme al curso: ${course}. Paquete: 8 sesiones de 1 hora. Precio: $2400 MXN. ¿Me confirmas horarios y forma de pago?`;
+      window.open(createWhatsAppUrl(message), "_blank", "noopener");
+    });
+  });
+};
+
+const setupTabs = () => {
+  tabButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const container = button.closest(".tabs");
+      if (!container) return;
+      const panelId = button.getAttribute("aria-controls");
+      const panels = container.querySelectorAll(".tab-panel");
+      const buttons = container.querySelectorAll(".tab");
+      buttons.forEach((btn) => btn.setAttribute("aria-selected", "false"));
+      panels.forEach((panel) => (panel.hidden = true));
+      button.setAttribute("aria-selected", "true");
+      const activePanel = container.querySelector(`#${panelId}`);
+      if (activePanel) activePanel.hidden = false;
+    });
+  });
+};
+
+const setupAdminTabs = () => {
+  adminTabButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const panelId = button.getAttribute("aria-controls");
+      adminTabButtons.forEach((btn) => btn.setAttribute("aria-selected", "false"));
+      document
+        .querySelectorAll("#adminPanel .tab-panel")
+        .forEach((panel) => (panel.hidden = true));
+      button.setAttribute("aria-selected", "true");
+      const panel = document.getElementById(panelId);
+      if (panel) panel.hidden = false;
+    });
+  });
+};
+
+const showNotification = () => {
+  const enabled = loadFromStorage(NOTIFICATION_ENABLED_KEY, true);
+  if (!enabled) return;
+  const message = loadFromStorage(NOTIFICATION_TEXT_KEY, DEFAULT_NOTIFICATION);
+  notificationMessage.textContent = safeText(message);
+  notificationToast.hidden = false;
+};
+
+const setupNotification = () => {
+  closeNotification.addEventListener("click", () => {
+    notificationToast.hidden = true;
+  });
+  showNotification();
+};
+
+const setAdminSession = () => {
+  const expiresAt = Date.now() + 2 * 60 * 60 * 1000;
+  sessionStorage.setItem(ADMIN_SESSION_KEY, JSON.stringify({ expiresAt }));
+};
+
+const hasAdminSession = () => {
+  const stored = sessionStorage.getItem(ADMIN_SESSION_KEY);
+  if (!stored) return false;
+  try {
+    const data = JSON.parse(stored);
+    return data.expiresAt > Date.now();
+  } catch (error) {
+    return false;
+  }
+};
+
+const openAdminModal = () => {
+  adminModal.classList.add("show");
+  adminModal.setAttribute("aria-hidden", "false");
+  if (hasAdminSession()) {
+    adminLogin.hidden = true;
+    adminPanel.hidden = false;
+  } else {
+    adminLogin.hidden = false;
+    adminPanel.hidden = true;
+  }
+};
+
+const closeAdminModal = () => {
+  adminModal.classList.remove("show");
+  adminModal.setAttribute("aria-hidden", "true");
+  adminLoginStatus.textContent = "";
+  adminPassword.value = "";
+};
+
+const handleAdminLogin = (event) => {
+  event.preventDefault();
+  const value = adminPassword.value.trim();
+  if (value === "2025" || value === "2010") {
+    setAdminSession();
+    adminLogin.hidden = true;
+    adminPanel.hidden = false;
+    adminLoginStatus.textContent = "";
+  } else {
+    adminLoginStatus.textContent = "Contraseña incorrecta.";
+  }
+};
+
+const handleAdminLogout = () => {
+  sessionStorage.removeItem(ADMIN_SESSION_KEY);
+  adminPanel.hidden = true;
+  adminLogin.hidden = false;
+};
+
+const handleProductSubmit = (event) => {
+  event.preventDefault();
+  const title = productTitle.value.trim();
+  const description = productDescription.value.trim();
+  const priceValue = parsePrice(productPrice.value);
+  const imageData = productPreview.dataset.image || productPreview.src;
+
+  if (!title || !description || priceValue === null) {
+    productFormStatus.textContent = "Completa todos los campos con datos válidos.";
+    return;
+  }
+
+  if (!imageData) {
+    productFormStatus.textContent = "Agrega una imagen del producto.";
+    return;
+  }
+
+  const now = Date.now();
+  if (editingMode === "pending" && editingPendingId) {
+    pendingProposals = pendingProposals.map((proposal) =>
+      proposal.id === editingPendingId
+        ? {
+            ...proposal,
+            title,
+            description,
+            price: priceValue,
+            imageDataUrl: imageData,
+            updatedAt: now,
+          }
+        : proposal
+    );
+    const saved = saveToStorage(PENDING_KEY, pendingProposals);
+    if (!saved) {
+      productFormStatus.textContent =
+        "No se pudo guardar. Reduce el tamaño de la imagen.";
+      return;
+    }
+    updatePendingList();
+  } else if (editingApprovedId) {
+    approvedProducts = approvedProducts.map((product) =>
+      product.id === editingApprovedId
+        ? {
+            ...product,
+            title,
+            description,
+            price: priceValue,
+            imageDataUrl: imageData,
+            updatedAt: now,
+          }
+        : product
+    );
+    const saved = saveToStorage(APPROVED_KEY, approvedProducts);
+    if (!saved) {
+      productFormStatus.textContent =
+        "No se pudo guardar. Reduce el tamaño de la imagen.";
+      return;
+    }
+    renderProducts();
+    updateAdminList();
+  } else {
+    approvedProducts.unshift({
+      id: generateId(),
+      title,
+      description,
+      price: priceValue,
+      imageDataUrl: imageData,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const saved = saveToStorage(APPROVED_KEY, approvedProducts);
+    if (!saved) {
+      productFormStatus.textContent =
+        "No se pudo guardar. Reduce el tamaño de la imagen.";
+      return;
+    }
+    renderProducts();
+    updateAdminList();
+  }
+
+  resetProductForm();
+  productForm.hidden = true;
+};
+
+const handleNotificationSave = (event) => {
+  event.preventDefault();
+  const message = notificationInput.value.trim();
+  if (!message) {
+    notificationStatus.textContent = "Escribe un mensaje válido.";
+    return;
+  }
+  saveToStorage(NOTIFICATION_TEXT_KEY, message);
+  saveToStorage(NOTIFICATION_ENABLED_KEY, notificationEnabled.checked);
+  notificationStatus.textContent = "Notificación actualizada.";
+};
+
+const handleExport = () => {
+  const payload = {
+    approved: approvedProducts,
+    pending: pendingProposals,
+    notification: loadFromStorage(NOTIFICATION_TEXT_KEY, DEFAULT_NOTIFICATION),
+    notificationEnabled: loadFromStorage(NOTIFICATION_ENABLED_KEY, true),
+  };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "lta_backup.json";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  settingsStatus.textContent = "Archivo exportado.";
+};
+
+const handleImport = (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const data = JSON.parse(reader.result);
+      if (Array.isArray(data.approved)) {
+        approvedProducts = data.approved;
+        saveToStorage(APPROVED_KEY, approvedProducts);
+        renderProducts();
+        updateAdminList();
+      }
+      if (Array.isArray(data.pending)) {
+        pendingProposals = data.pending;
+        saveToStorage(PENDING_KEY, pendingProposals);
+        updatePendingList();
+      }
+      if (data.notification) {
+        saveToStorage(NOTIFICATION_TEXT_KEY, data.notification);
+      }
+      if (typeof data.notificationEnabled === "boolean") {
+        saveToStorage(NOTIFICATION_ENABLED_KEY, data.notificationEnabled);
+        notificationEnabled.checked = data.notificationEnabled;
+      }
+      settingsStatus.textContent = "Datos importados correctamente.";
+    } catch (error) {
+      settingsStatus.textContent = "Archivo inválido.";
+    }
+  };
+  reader.readAsText(file);
+};
+
+const updateGame = () => {
+  const a = Math.floor(Math.random() * 9) + 1;
+  const b = Math.floor(Math.random() * 9) + 1;
+  const operator = Math.random() > 0.5 ? "+" : "-";
+  const result = operator === "+" ? a + b : a - b;
+  currentGame = { a, b, operator, result };
+  gameQuestion.textContent = `${a} ${operator} ${b} = ?`;
+  gameAnswer.value = "";
+  gameFeedback.textContent = "";
+};
+
+const handleGameSubmit = () => {
+  if (!currentGame) return;
+  const answer = Number.parseInt(gameAnswer.value, 10);
+  if (Number.isNaN(answer)) {
+    gameFeedback.textContent = "Escribe una respuesta válida.";
+    return;
+  }
+  if (answer === currentGame.result) {
+    gameFeedback.textContent = "¡Correcto!";
+  } else {
+    gameFeedback.textContent = "Respuesta incorrecta. Intenta de nuevo.";
+  }
+};
+
+const setStudentSession = () => {
+  const expiresAt = Date.now() + 2 * 60 * 60 * 1000;
+  sessionStorage.setItem(STUDENT_SESSION_KEY, JSON.stringify({ expiresAt }));
+};
+
+const hasStudentSession = () => {
+  const stored = sessionStorage.getItem(STUDENT_SESSION_KEY);
+  if (!stored) return false;
+  try {
+    const data = JSON.parse(stored);
+    return data.expiresAt > Date.now();
+  } catch (error) {
+    return false;
+  }
+};
+
+const loadStudentContent = () => {
+  const data = loadFromStorage(STUDENT_CONTENT_KEY, {
+    content: "Bienvenido al panel de estudiantes.",
+    date: "",
+    number: "",
+  });
+  studentContent.value = data.content;
+  studentDate.value = data.date;
+  studentNumber.value = data.number;
+  studentPreview.textContent = `${data.content} ${data.date ? `· ${data.date}` : ""} ${
+    data.number ? `· ${data.number}` : ""
+  }`;
+};
+
+const handleStudentLogin = (event) => {
+  event.preventDefault();
+  const value = studentPassword.value.trim();
+  if (value === "2025" || value === "1991") {
+    setStudentSession();
+    studentPanel.hidden = false;
+    studentLoginStatus.textContent = "Acceso correcto.";
+    loadStudentContent();
+  } else {
+    studentLoginStatus.textContent = "Contraseña incorrecta.";
+  }
+};
+
+const handleStudentLogout = () => {
+  sessionStorage.removeItem(STUDENT_SESSION_KEY);
+  studentPanel.hidden = true;
+  studentLoginStatus.textContent = "Sesión cerrada.";
+};
+
+const handleStudentSave = (event) => {
+  event.preventDefault();
+  const payload = {
+    content: studentContent.value.trim(),
+    date: studentDate.value,
+    number: studentNumber.value,
+  };
+  saveToStorage(STUDENT_CONTENT_KEY, payload);
+  studentPreview.textContent = `${payload.content} ${payload.date ? `· ${payload.date}` : ""} ${
+    payload.number ? `· ${payload.number}` : ""
+  }`;
+  studentSaveStatus.textContent = "Cambios guardados.";
+};
+
+const setupContactForm = () => {
+  contactForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    contactStatus.textContent = "Mensaje enviado. Te contactaremos pronto.";
+    contactForm.reset();
+  });
+};
+
+const handleProposalSubmit = (event) => {
+  event.preventDefault();
+  const title = proposalTitle.value.trim();
+  const description = proposalDescription.value.trim();
+  const priceValue = parsePrice(proposalPrice.value);
+  const imageData = proposalPreview.dataset.image || proposalPreview.src;
+
+  if (!title || !description || priceValue === null) {
+    proposalStatus.textContent = "Completa los campos con datos válidos.";
+    return;
+  }
+
+  if (!imageData) {
+    proposalStatus.textContent = "Agrega una imagen para enviar la propuesta.";
+    return;
+  }
+
+  const proposal = {
+    id: generateId(),
+    title,
+    description,
+    price: priceValue,
+    imageDataUrl: imageData,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+
+  pendingProposals.unshift(proposal);
+  const saved = saveToStorage(PENDING_KEY, pendingProposals);
+  if (!saved) {
+    pendingProposals.shift();
+    proposalStatus.textContent =
+      "No se pudo guardar. Usa una imagen más ligera.";
+    return;
+  }
+
+  proposalStatus.textContent = "Propuesta enviada. Será revisada.";
+  proposalForm.reset();
+  proposalPreview.hidden = true;
+  proposalPreview.src = "";
+  proposalPreview.dataset.image = "";
+  updatePendingList();
+};
+
+const setupAdminEvents = () => {
+  openAdmin.addEventListener("click", openAdminModal);
+  closeAdmin.addEventListener("click", closeAdminModal);
+  adminModal.addEventListener("click", (event) => {
+    if (event.target === adminModal) closeAdminModal();
+  });
+  adminLoginForm.addEventListener("submit", handleAdminLogin);
+  adminLogout.addEventListener("click", handleAdminLogout);
+  newProductBtn.addEventListener("click", () => {
+    resetProductForm();
+    productForm.hidden = false;
+  });
+  cancelProduct.addEventListener("click", () => {
+    productForm.hidden = true;
+    resetProductForm();
+  });
+  productImageBtn.addEventListener("click", () => productImage.click());
+  productImage.addEventListener("change", (event) =>
+    handleImageDrop({
+      file: event.target.files?.[0],
+      previewEl: productPreview,
+      statusEl: productFormStatus,
+    })
+  );
+  adminDropzone.addEventListener("dragover", (event) => {
+    event.preventDefault();
+    adminDropzone.classList.add("is-dragging");
+  });
+  adminDropzone.addEventListener("dragleave", () => {
+    adminDropzone.classList.remove("is-dragging");
+  });
+  adminDropzone.addEventListener("drop", (event) => {
+    event.preventDefault();
+    adminDropzone.classList.remove("is-dragging");
+    const file = event.dataTransfer?.files?.[0];
+    handleImageDrop({ file, previewEl: productPreview, statusEl: productFormStatus });
+  });
+  productDescription.addEventListener("input", () => {
+    descCount.textContent = `${productDescription.value.length}/220`;
+  });
+  productForm.addEventListener("submit", handleProductSubmit);
+  adminWhatsApp.addEventListener("click", () => {
+    const title = productTitle.value.trim() || "Sin título";
+    const priceValue = parsePrice(productPrice.value) ?? 0;
+    const message = `Hola Alberto. Estoy publicando/actualizando un producto en LA TIENDA DE ALBERTO. Producto: ${title}. Precio: $${priceValue} MXN. (Adjunto imagen si aplica).`;
+    window.open(createWhatsAppUrl(message), "_blank", "noopener");
+  });
+  notificationForm.addEventListener("submit", handleNotificationSave);
+  exportDataBtn.addEventListener("click", handleExport);
+  importDataBtn.addEventListener("click", () => importDataInput.click());
+  importDataInput.addEventListener("change", handleImport);
+};
+
+const setupProposalEvents = () => {
+  proposalImageBtn.addEventListener("click", () => proposalImage.click());
+  proposalImage.addEventListener("change", (event) =>
+    handleImageDrop({
+      file: event.target.files?.[0],
+      previewEl: proposalPreview,
+      statusEl: proposalStatus,
+    })
+  );
+  proposalDropzone.addEventListener("dragover", (event) => {
+    event.preventDefault();
+    proposalDropzone.classList.add("is-dragging");
+  });
+  proposalDropzone.addEventListener("dragleave", () => {
+    proposalDropzone.classList.remove("is-dragging");
+  });
+  proposalDropzone.addEventListener("drop", (event) => {
+    event.preventDefault();
+    proposalDropzone.classList.remove("is-dragging");
+    const file = event.dataTransfer?.files?.[0];
+    handleImageDrop({ file, previewEl: proposalPreview, statusEl: proposalStatus });
+  });
+  proposalForm.addEventListener("submit", handleProposalSubmit);
+};
+
+const initializeNotificationForm = () => {
+  notificationInput.value = loadFromStorage(
+    NOTIFICATION_TEXT_KEY,
+    DEFAULT_NOTIFICATION
+  );
+  notificationEnabled.checked = loadFromStorage(NOTIFICATION_ENABLED_KEY, true);
+};
+
+const init = () => {
+  loadApproved();
+  loadPending();
+  renderProducts();
+  updateAdminList();
+  updatePendingList();
+  setupCourseButtons();
+  setupTabs();
+  setupAdminTabs();
+  setupNotification();
+  setupAdminEvents();
+  setupProposalEvents();
+  initializeNotificationForm();
+  updateGame();
+  gameSubmit.addEventListener("click", handleGameSubmit);
+  gameReset.addEventListener("click", updateGame);
+  searchInput.addEventListener("input", renderProducts);
+  sortSelect.addEventListener("change", renderProducts);
+  studentLoginForm.addEventListener("submit", handleStudentLogin);
+  studentLogout.addEventListener("click", handleStudentLogout);
+  studentEditForm.addEventListener("submit", handleStudentSave);
+  setupContactForm();
+
+  if (hasAdminSession()) {
+    adminLogin.hidden = true;
+    adminPanel.hidden = false;
+  }
+
+  if (hasStudentSession()) {
+    studentPanel.hidden = false;
+    loadStudentContent();
+  }
+};
+
+init();


### PR DESCRIPTION
### Motivation
- Provide a complete, static and responsive storefront called “LA TIENDA DE ALBERTO” that runs directly from `/htdocs/index.html` and uses only HTML/CSS/vanilla JS with localStorage persistence. 
- Allow collaborators to propose products (saved as pending) while keeping publication control to the administrator. 
- Include clear WhatsApp contact CTAs and transparent commission messaging (20%) for buyers and sellers. 
- Offer lightweight admin/student editing, notifications and backup/import to manage the site without a server.

### Description
- Rebuilt the site entrypoint `index.html` and added `css/styles.css` and `js/app.js` implementing catalog, courses, interactive game, student editor, contact form, proposal submission and an admin modal with tabs (`Pendientes`, `Productos`, `Notificaciones`, `Ajustes`).
- Implemented proposal workflow with drag & drop + file input image handling, client-side image compression (max 1200px, JPEG ~0.75) and two persistent lists in `localStorage` using keys `LTA_APPROVED_V1` and `LTA_PENDING_V1`, plus notification keys `LTA_NOTIFICATION_TEXT_V1` and `LTA_NOTIFICATION_ENABLED_V1` and session keys `LTA_ADMIN_SESSION_V1`/`LTA_STUDENT_SESSION_V1`.
- Admin actions include approve/reject/edit pending proposals, full CRUD for approved products, edit notification toast, and export/import backup JSON; WhatsApp buttons open `wa.me` links with prefilled messages for courses and purchases.
- Project structure and README updated so the ZIP root contains `index.html`, `css/styles.css`, `js/app.js` and instructions to upload directly to `/htdocs` (no wrapper folder), and the UI follows the requested visual palette, accessibility and validation rules.

### Testing
- Basic smoke test: served the site locally with `python -m http.server 8000` and captured a full-page screenshot using Playwright which loaded the page (screenshot artifact created successfully). 
- Manual interactive checks exercised: course WhatsApp buttons, tab navigation, admin modal open/close, and proposal submission UI for client-side behavior (no automated unit tests were run). 
- LocalStorage persistence paths were exercised by creating demo approved products and submitting a proposal to ensure `LTA_APPROVED_V1` and `LTA_PENDING_V1` are created and stored. 
- Export/import backup flow was tested by invoking the JSON export (file download initiated) and import handler (file parsing validated) in the browser during the smoke run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6fdc2a188325b680588db3367d76)