### PR TITLE
Mejora: categorías, múltiples imágenes, mensajes privados y estilo moderno

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,13 +1,13 @@
 :root {
   color-scheme: light;
-  --bg: #071127;
-  --bg-alt: #0e1c3a;
+  --bg: #0b1224;
+  --bg-alt: #151e3a;
   --card: #ffffff;
   --text: #0d1224;
   --muted: #5b657a;
-  --accent: #f0c75e;
-  --cta: #1dbba7;
-  --cta-dark: #129483;
+  --accent: #f472b6;
+  --cta: #6366f1;
+  --cta-dark: #4f46e5;
   --border: rgba(13, 18, 36, 0.12);
   --shadow: 0 20px 40px rgba(6, 18, 40, 0.12);
   --radius: 18px;
@@ -23,7 +23,7 @@ body {
   margin: 0;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--text);
-  background: #f5f7fb;
+  background: #ffffff;
   line-height: 1.6;
 }
 
@@ -78,22 +78,24 @@ a:focus-visible {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: var(--bg);
+  background: linear-gradient(120deg, #0b1224, #1b2450);
   color: #fff;
   box-shadow: 0 8px 20px rgba(4, 10, 26, 0.4);
 }
 
 .header-grid {
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: 1fr;
   gap: 1rem;
   align-items: center;
+  text-align: center;
   padding: 1.5rem 0;
 }
 
 .brand h1 {
   margin: 0;
-  font-size: clamp(1.5rem, 2.5vw, 2.3rem);
+  font-size: clamp(2.4rem, 5vw, 4.2rem);
+  letter-spacing: 0.08em;
 }
 
 .brand-kicker {
@@ -108,6 +110,7 @@ a:focus-visible {
   gap: 1rem;
   flex-wrap: wrap;
   font-weight: 600;
+  justify-content: center;
 }
 
 .main-nav a {
@@ -127,10 +130,11 @@ a:focus-visible {
   padding: 0.4rem 0.85rem;
   border-radius: 999px;
   cursor: pointer;
+  justify-self: center;
 }
 
 .contact-bar {
-  background: var(--bg-alt);
+  background: rgba(21, 30, 58, 0.9);
   padding: 0.75rem 0;
 }
 
@@ -167,7 +171,7 @@ a:focus-visible {
 .btn-primary {
   background: var(--cta);
   color: #fff;
-  box-shadow: 0 10px 20px rgba(29, 187, 167, 0.35);
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.35);
 }
 
 .btn-primary:hover {
@@ -181,7 +185,7 @@ a:focus-visible {
 }
 
 .btn-whatsapp {
-  background: #1f8c75;
+  background: #16a34a;
   color: #fff;
 }
 
@@ -190,7 +194,7 @@ a:focus-visible {
 }
 
 .hero {
-  background: radial-gradient(circle at top, #18274d, var(--bg));
+  background: radial-gradient(circle at top, #1e2a5a, var(--bg));
   color: #fff;
   padding: 4rem 0;
 }
@@ -246,7 +250,7 @@ a:focus-visible {
 }
 
 .alt-section {
-  background: #f0f3fb;
+  background: #f8f9ff;
 }
 
 .section-head {
@@ -330,6 +334,20 @@ a:focus-visible {
   border-radius: var(--radius);
   padding: 1.5rem;
   border: 1px solid var(--border);
+  position: relative;
+  animation: floatCard 6s ease-in-out infinite;
+}
+
+.step-card:nth-child(2) {
+  animation-delay: 0.4s;
+}
+
+.step-card:nth-child(3) {
+  animation-delay: 0.8s;
+}
+
+.step-card:nth-child(4) {
+  animation-delay: 1.2s;
 }
 
 .product-card .price {
@@ -378,6 +396,43 @@ a:focus-visible {
   max-height: 180px;
   border-radius: 12px;
   object-fit: cover;
+}
+
+.preview-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  margin-top: 1rem;
+}
+
+.preview-grid img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.flow-banner {
+  overflow: hidden;
+  background: #0f172a;
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.5rem 0;
+  margin-bottom: 2rem;
+}
+
+.flow-track {
+  display: flex;
+  gap: 2rem;
+  white-space: nowrap;
+  animation: flow 18s linear infinite;
+}
+
+.flow-track span {
+  display: inline-flex;
+  gap: 1.5rem;
+  font-weight: 600;
+  padding-left: 1rem;
 }
 
 .tabs {
@@ -462,6 +517,49 @@ a:focus-visible {
   padding: 1rem;
   border-radius: 12px;
   background: #f7f9ff;
+}
+
+.tag-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.tag {
+  background: #eef2ff;
+  color: #4338ca;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.tag-alt {
+  background: #fdf2f8;
+  color: #be185d;
+}
+
+.mini-gallery {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.mini-gallery img {
+  width: 70px;
+  height: 70px;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+.message-form {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
 }
 
 .site-footer {
@@ -553,6 +651,15 @@ a:focus-visible {
   border-radius: 14px;
 }
 
+.admin-item.message-item {
+  grid-template-columns: 1fr auto;
+}
+
+.admin-item.is-unread {
+  border: 1px solid rgba(99, 102, 241, 0.5);
+  background: #eef2ff;
+}
+
 .admin-item img {
   width: 80px;
   height: 80px;
@@ -609,5 +716,24 @@ a:focus-visible {
   .admin-item {
     grid-template-columns: 1fr;
     text-align: left;
+  }
+}
+
+@keyframes flow {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes floatCard {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
   }
 }

--- a/index.html
+++ b/index.html
@@ -16,10 +16,10 @@
       </div>
       <nav class="main-nav" aria-label="Principal">
         <a href="#inicio">Inicio</a>
-        <a href="#como-funciona">Cómo funciona</a>
+        <a href="#como-funciona">Cómo ofrecer tu producto o servicio</a>
+        <a href="#propuestas">Propón tu producto</a>
         <a href="#cursos">Cursos</a>
         <a href="#catalogo">Catálogo</a>
-        <a href="#propuestas">Propón tu producto</a>
         <a href="#interactivo">Zona interactiva</a>
       </nav>
       <button class="admin-button" id="openAdmin" type="button">Admin</button>
@@ -28,9 +28,9 @@
       <div class="container contact-bar-inner">
         <div class="contact-info">
           <span>WhatsApp directo</span>
-          <strong>+52 56 1088 5357</strong>
+          <strong>+52 56 1088 5857</strong>
         </div>
-        <a class="btn btn-whatsapp" id="topWhatsapp" href="https://wa.me/525610885357?text=Hola%20Alberto,%20quiero%20informaci%C3%B3n%20por%20favor." target="_blank" rel="noopener">Contactar</a>
+        <a class="btn btn-whatsapp" id="topWhatsapp" href="https://wa.me/525610885857?text=Hola%20Alberto,%20quiero%20informaci%C3%B3n%20por%20favor." target="_blank" rel="noopener">Contactar</a>
       </div>
     </div>
   </header>
@@ -40,8 +40,8 @@
       <div class="container hero-grid">
         <div>
           <p class="eyebrow">Confianza y claridad para aprender y vender</p>
-          <h2>Aprende matemáticas y vende tus productos con respaldo.</h2>
-          <p class="lead">Cursos intensivos y catálogo verificado. Comunicación directa por WhatsApp con procesos claros.</p>
+          <h2>Aprende matemáticas y ofrece tus productos o servicios con respaldo.</h2>
+          <p class="lead">Cursos intensivos y escaparate verificado. Comunicación directa por WhatsApp con procesos claros.</p>
           <div class="hero-cta">
             <a class="btn btn-primary" href="#cursos">Ver cursos</a>
             <a class="btn btn-ghost" href="#catalogo">Explorar catálogo</a>
@@ -66,27 +66,186 @@
     <section id="como-funciona" class="section">
       <div class="container">
         <div class="section-head">
-          <h2>Cómo funciona</h2>
-          <p>Proceso claro para colaboradores y compradores.</p>
+          <h2>Cómo ofrecer tu producto o servicio</h2>
+          <p>Proceso directo, claro y sin pasos ocultos.</p>
+        </div>
+        <div class="flow-banner" aria-hidden="true">
+          <div class="flow-track">
+            <span>📸 Sube fotos · 📝 Describe tu producto o servicio · ✅ Revisión y aprobación · 💬 Contacto por WhatsApp · 20% comisión por exhibición ·</span>
+            <span>📸 Sube fotos · 📝 Describe tu producto o servicio · ✅ Revisión y aprobación · 💬 Contacto por WhatsApp · 20% comisión por exhibición ·</span>
+          </div>
         </div>
         <div class="steps-grid">
           <article class="step-card">
-            <h3>1. Propón tu producto</h3>
-            <p>Envía imagen, descripción y precio. Tu propuesta queda en revisión.</p>
+            <h3>1. Envía tu propuesta</h3>
+            <p>Sube una o más fotos, agrega descripción (máx 220) y elige si es producto o servicio.</p>
           </article>
           <article class="step-card">
             <h3>2. Se revisa y aprueba</h3>
-            <p>Al aprobarse, el producto aparece en el catálogo público.</p>
+            <p>Tu propuesta pasa por revisión y aprobación antes de publicarse.</p>
           </article>
           <article class="step-card">
-            <h3>3. Compradores contactan</h3>
-            <p>Los interesados te escriben por WhatsApp para cerrar la venta.</p>
+            <h3>3. Contacto directo</h3>
+            <p>Los interesados se comunican por WhatsApp y coordinan entrega contigo.</p>
+          </article>
+          <article class="step-card">
+            <h3>4. Comisión transparente</h3>
+            <p>Se cobra 20% por la exhibición del producto o servicio. No cubrimos envíos.</p>
           </article>
         </div>
       </div>
     </section>
 
-    <section id="confianza" class="section alt-section">
+    <section id="propuestas" class="section">
+      <div class="container">
+        <div class="section-head">
+          <h2>Propón tu producto o servicio</h2>
+          <p>Envía tu propuesta y se revisa para aprobación. Solo el administrador publica.</p>
+        </div>
+        <div class="publica-grid">
+          <form id="proposalForm" class="card form-grid">
+            <div class="dropzone" id="proposalDropzone">
+              <p><strong>Arrastra y suelta tus imágenes</strong></p>
+              <p class="muted">o</p>
+              <input type="file" id="proposalImage" accept="image/*" multiple hidden>
+              <button class="btn btn-ghost" id="proposalImageBtn" type="button">Subir imágenes</button>
+              <div class="preview-grid" id="proposalPreview" hidden></div>
+            </div>
+            <label class="field">
+              <span>Tipo</span>
+              <select id="proposalType" required>
+                <option value="">Selecciona</option>
+                <option value="Producto">Producto</option>
+                <option value="Servicio">Servicio</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Categoría</span>
+              <select id="proposalCategory" required>
+                <option value="">Selecciona</option>
+                <option>Hogar</option>
+                <option>Electrónica</option>
+                <option>Moda</option>
+                <option>Salud &amp; bienestar</option>
+                <option>Comida</option>
+                <option>Educación</option>
+                <option>Servicios profesionales</option>
+                <option>Otros</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Título</span>
+              <input type="text" id="proposalTitle" required>
+            </label>
+            <label class="field">
+              <span>Mini-descripción (máx 220, sin precio)</span>
+              <textarea id="proposalDescription" maxlength="220" rows="3" required></textarea>
+            </label>
+            <label class="field">
+              <span>Precio MXN</span>
+              <input type="text" id="proposalPrice" placeholder="350.50" required>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" id="proposalSchedule">
+              <span>Agregar calendario de fechas</span>
+            </label>
+            <div class="field-row" id="proposalDates" hidden>
+              <label class="field">
+                <span>Inicio</span>
+                <input type="date" id="proposalStartDate">
+              </label>
+              <label class="field">
+                <span>Fin</span>
+                <input type="date" id="proposalEndDate">
+              </label>
+            </div>
+            <button class="btn btn-primary" type="submit">Enviar propuesta</button>
+            <p id="proposalStatus" class="muted proposal-status" aria-live="polite"></p>
+          </form>
+          <div class="publica-info">
+            <h3>¿Qué sucede después?</h3>
+            <ul>
+              <li>Tu propuesta queda en revisión</li>
+              <li>Recibirás confirmación al aprobarse</li>
+              <li>La comisión es del 20% por exhibición</li>
+            </ul>
+            <p class="muted">Nosotros solo conectamos a compradores y vendedores vía WhatsApp.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="cursos" class="section">
+      <div class="container">
+        <div class="section-head">
+          <h2>Cursos en línea</h2>
+          <p>8 sesiones de 1 hora · Atención personalizada · Precio fijo</p>
+        </div>
+        <div class="card-grid">
+          <article class="card course-card">
+            <h3>Álgebra</h3>
+            <p>8 sesiones de 1 hora</p>
+            <p class="muted">Inicio: 15 de marzo · Fin: 15 de abril</p>
+            <p class="price">$2400 MXN</p>
+            <button class="btn btn-whatsapp" data-course="Álgebra">Solicitar por WhatsApp</button>
+          </article>
+          <article class="card course-card">
+            <h3>Cálculo Diferencial</h3>
+            <p>8 sesiones de 1 hora</p>
+            <p class="muted">Inicio: 2 de abril · Fin: 2 de mayo</p>
+            <p class="price">$2400 MXN</p>
+            <button class="btn btn-whatsapp" data-course="Cálculo Diferencial">Solicitar por WhatsApp</button>
+          </article>
+          <article class="card course-card">
+            <h3>Cálculo Integral</h3>
+            <p>8 sesiones de 1 hora</p>
+            <p class="muted">Inicio: 20 de abril · Fin: 20 de mayo</p>
+            <p class="price">$2400 MXN</p>
+            <button class="btn btn-whatsapp" data-course="Cálculo Integral">Solicitar por WhatsApp</button>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="catalogo" class="section alt-section">
+      <div class="container">
+        <div class="section-head">
+          <h2>Catálogo</h2>
+          <p>Productos y servicios aprobados, listos para comprar.</p>
+        </div>
+        <div class="filters">
+          <label class="field">
+            <span>Buscar</span>
+            <input type="search" id="searchInput" placeholder="Buscar por título o descripción">
+          </label>
+          <label class="field">
+            <span>Categoría</span>
+            <select id="categorySelect">
+              <option value="all">Todas</option>
+              <option>Hogar</option>
+              <option>Electrónica</option>
+              <option>Moda</option>
+              <option>Salud &amp; bienestar</option>
+              <option>Comida</option>
+              <option>Educación</option>
+              <option>Servicios profesionales</option>
+              <option>Otros</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Ordenar por</span>
+            <select id="sortSelect">
+              <option value="recent">Más recientes</option>
+              <option value="price-asc">Precio: menor a mayor</option>
+              <option value="price-desc">Precio: mayor a menor</option>
+            </select>
+          </label>
+        </div>
+        <div id="productGrid" class="card-grid"></div>
+      </div>
+    </section>
+
+    <section id="confianza" class="section">
       <div class="container">
         <div class="section-head">
           <h2>Confianza y transparencia</h2>
@@ -105,101 +264,6 @@
             <h3>Catálogo curado</h3>
             <p>Solo se publican productos aprobados por el administrador.</p>
           </article>
-        </div>
-      </div>
-    </section>
-
-    <section id="cursos" class="section">
-      <div class="container">
-        <div class="section-head">
-          <h2>Cursos en línea</h2>
-          <p>8 sesiones de 1 hora · Atención personalizada · Precio fijo</p>
-        </div>
-        <div class="card-grid">
-          <article class="card course-card">
-            <h3>Álgebra</h3>
-            <p>8 sesiones de 1 hora</p>
-            <p class="price">$2400 MXN</p>
-            <button class="btn btn-whatsapp" data-course="Álgebra">Inscribirme por WhatsApp</button>
-          </article>
-          <article class="card course-card">
-            <h3>Cálculo Diferencial</h3>
-            <p>8 sesiones de 1 hora</p>
-            <p class="price">$2400 MXN</p>
-            <button class="btn btn-whatsapp" data-course="Cálculo Diferencial">Inscribirme por WhatsApp</button>
-          </article>
-          <article class="card course-card">
-            <h3>Cálculo Integral</h3>
-            <p>8 sesiones de 1 hora</p>
-            <p class="price">$2400 MXN</p>
-            <button class="btn btn-whatsapp" data-course="Cálculo Integral">Inscribirme por WhatsApp</button>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section id="catalogo" class="section alt-section">
-      <div class="container">
-        <div class="section-head">
-          <h2>Catálogo</h2>
-          <p>Productos y servicios aprobados, listos para comprar.</p>
-        </div>
-        <div class="filters">
-          <label class="field">
-            <span>Buscar</span>
-            <input type="search" id="searchInput" placeholder="Buscar por título o descripción">
-          </label>
-          <label class="field">
-            <span>Ordenar por</span>
-            <select id="sortSelect">
-              <option value="recent">Más recientes</option>
-              <option value="price-asc">Precio: menor a mayor</option>
-              <option value="price-desc">Precio: mayor a menor</option>
-            </select>
-          </label>
-        </div>
-        <div id="productGrid" class="card-grid"></div>
-      </div>
-    </section>
-
-    <section id="propuestas" class="section">
-      <div class="container">
-        <div class="section-head">
-          <h2>Propón tu producto o servicio</h2>
-          <p>Envía tu propuesta y se revisa para aprobación. Solo el administrador publica.</p>
-        </div>
-        <div class="publica-grid">
-          <form id="proposalForm" class="card form-grid">
-            <div class="dropzone" id="proposalDropzone">
-              <p><strong>Arrastra y suelta tu imagen</strong></p>
-              <p class="muted">o</p>
-              <input type="file" id="proposalImage" accept="image/*" hidden>
-              <button class="btn btn-ghost" id="proposalImageBtn" type="button">Subir imagen</button>
-              <img class="preview" id="proposalPreview" alt="Vista previa" hidden>
-            </div>
-            <label class="field">
-              <span>Título</span>
-              <input type="text" id="proposalTitle" required>
-            </label>
-            <label class="field">
-              <span>Mini-descripción (máx 220)</span>
-              <textarea id="proposalDescription" maxlength="220" rows="3" required></textarea>
-            </label>
-            <label class="field">
-              <span>Precio MXN</span>
-              <input type="text" id="proposalPrice" placeholder="350.50" required>
-            </label>
-            <button class="btn btn-primary" type="submit">Enviar propuesta</button>
-            <p id="proposalStatus" class="muted proposal-status" aria-live="polite"></p>
-          </form>
-          <div class="publica-info">
-            <h3>¿Qué sucede después?</h3>
-            <ul>
-              <li>Tu propuesta queda en revisión</li>
-              <li>Recibirás confirmación al aprobarse</li>
-              <li>La comisión es del 20% por venta</li>
-            </ul>
-          </div>
         </div>
       </div>
     </section>
@@ -305,10 +369,10 @@
               </form>
               <div class="card">
                 <h3>Información básica</h3>
-                <p><strong>WhatsApp:</strong> +52 56 1088 5357</p>
+                <p><strong>WhatsApp:</strong> +52 56 1088 5857</p>
                 <p><strong>Horario:</strong> Lunes a sábado, 9:00 - 19:00</p>
                 <p><strong>Ubicación:</strong> Ciudad de México</p>
-                <a class="btn btn-whatsapp" id="contactWhatsapp" href="https://wa.me/525610885357?text=Hola%20Alberto,%20quiero%20informaci%C3%B3n%20por%20favor." target="_blank" rel="noopener">Contactar por WhatsApp</a>
+                <a class="btn btn-whatsapp" id="contactWhatsapp" href="https://wa.me/525610885857?text=Hola%20Alberto,%20quiero%20informaci%C3%B3n%20por%20favor." target="_blank" rel="noopener">Contactar por WhatsApp</a>
               </div>
             </div>
           </div>
@@ -326,8 +390,8 @@
       </div>
       <div class="footer-contact">
         <span>WhatsApp</span>
-        <strong>+52 56 1088 5357</strong>
-        <a class="btn btn-whatsapp" id="bottomWhatsapp" href="https://wa.me/525610885357?text=Hola%20Alberto,%20quiero%20informaci%C3%B3n%20por%20favor." target="_blank" rel="noopener">Contactar</a>
+        <strong>+52 56 1088 5857</strong>
+        <a class="btn btn-whatsapp" id="bottomWhatsapp" href="https://wa.me/525610885857?text=Hola%20Alberto,%20quiero%20informaci%C3%B3n%20por%20favor." target="_blank" rel="noopener">Contactar</a>
       </div>
     </div>
   </footer>
@@ -345,7 +409,7 @@
       <button class="modal-close" id="closeAdmin" type="button" aria-label="Cerrar">×</button>
       <h2 id="adminTitle">Panel administrador</h2>
       <div id="adminLogin">
-        <p class="muted">Acceso solo administrador. Contraseñas válidas: 2025 o 2010.</p>
+        <p class="muted">Acceso solo administrador. Protege tus credenciales.</p>
         <form id="adminLoginForm">
           <label class="field">
             <span>Contraseña</span>
@@ -360,6 +424,7 @@
           <div class="tab-list" role="tablist" aria-label="Panel administrador">
             <button class="tab" role="tab" aria-selected="true" aria-controls="admin-pending" id="admin-pending-btn">Pendientes</button>
             <button class="tab" role="tab" aria-selected="false" aria-controls="admin-products" id="admin-products-btn">Productos</button>
+            <button class="tab" role="tab" aria-selected="false" aria-controls="admin-messages" id="admin-messages-btn">Mensajes</button>
             <button class="tab" role="tab" aria-selected="false" aria-controls="admin-notifications" id="admin-notifications-btn">Notificaciones</button>
             <button class="tab" role="tab" aria-selected="false" aria-controls="admin-settings" id="admin-settings-btn">Ajustes</button>
           </div>
@@ -380,18 +445,40 @@
           <form id="productForm" class="card" hidden>
             <h3 id="productFormTitle">Nuevo producto</h3>
             <div class="dropzone" id="adminDropzone">
-              <p><strong>Arrastra tu imagen aquí</strong></p>
+              <p><strong>Arrastra tus imágenes aquí</strong></p>
               <p class="muted">o</p>
-              <input type="file" id="productImage" accept="image/*" hidden>
-              <button class="btn btn-ghost" id="productImageBtn" type="button">Seleccionar imagen</button>
-              <img id="productPreview" alt="Vista previa" hidden>
+              <input type="file" id="productImage" accept="image/*" multiple hidden>
+              <button class="btn btn-ghost" id="productImageBtn" type="button">Seleccionar imágenes</button>
+              <div class="preview-grid" id="productPreview" hidden></div>
             </div>
+            <label class="field">
+              <span>Tipo</span>
+              <select id="productType" required>
+                <option value="">Selecciona</option>
+                <option value="Producto">Producto</option>
+                <option value="Servicio">Servicio</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Categoría</span>
+              <select id="productCategory" required>
+                <option value="">Selecciona</option>
+                <option>Hogar</option>
+                <option>Electrónica</option>
+                <option>Moda</option>
+                <option>Salud &amp; bienestar</option>
+                <option>Comida</option>
+                <option>Educación</option>
+                <option>Servicios profesionales</option>
+                <option>Otros</option>
+              </select>
+            </label>
             <label class="field">
               <span>Título</span>
               <input type="text" id="productTitle" required>
             </label>
             <label class="field">
-              <span>Mini-descripción</span>
+              <span>Mini-descripción (máx 220, sin precio)</span>
               <textarea id="productDescription" maxlength="220" rows="3" required></textarea>
               <small id="descCount">0/220</small>
             </label>
@@ -399,6 +486,20 @@
               <span>Precio MXN</span>
               <input type="text" id="productPrice" placeholder="350.50" required>
             </label>
+            <label class="checkbox">
+              <input type="checkbox" id="productSchedule">
+              <span>Agregar calendario de fechas</span>
+            </label>
+            <div class="field-row" id="productDates" hidden>
+              <label class="field">
+                <span>Inicio</span>
+                <input type="date" id="productStartDate">
+              </label>
+              <label class="field">
+                <span>Fin</span>
+                <input type="date" id="productEndDate">
+              </label>
+            </div>
             <div class="form-actions">
               <button class="btn btn-primary" type="submit">Guardar</button>
               <button class="btn btn-whatsapp" id="adminWhatsApp" type="button">Avisar por WhatsApp</button>
@@ -406,6 +507,14 @@
             </div>
             <p id="productFormStatus" class="muted" aria-live="polite"></p>
           </form>
+        </div>
+
+        <div id="admin-messages" class="tab-panel" role="tabpanel" aria-labelledby="admin-messages-btn" hidden>
+          <div class="card">
+            <h3>Mensajes privados</h3>
+            <p class="muted">Mensajes enviados desde el catálogo. Solo tú los puedes leer aquí.</p>
+          </div>
+          <div id="adminMessagesList" class="admin-list"></div>
         </div>
 
         <div id="admin-notifications" class="tab-panel" role="tabpanel" aria-labelledby="admin-notifications-btn" hidden>


### PR DESCRIPTION
### Motivation
- Adaptar la tienda a la nueva propuesta de flujo: mostrar "Cómo ofrecer tu producto o servicio" primero y apoyar productos/servicios con imágenes, categoría y calendario opcional.
- Evitar exponer contraseñas en la UI del administrador y proporcionar un panel privado para mensajes recibidos desde el catálogo.
- Hacer la interfaz más moderna, blanca y llamativa con microanimaciones para destacar el proceso y el encabezado principal.
- Mejorar compatibilidad móvil y la experiencia de propuesta/edición rápida tanto para administradores como para estudiantes.

### Description
- Reorganiza y renombra secciones en `index.html`, añade banner animado de flujo, mueve y amplía la sección de propuestas y cursos, y actualiza todos los enlaces de WhatsApp al nuevo número `+52 56 1088 5857`.
- Añade soporte para múltiples imágenes, `type` (Producto/Servicio), `category` y calendario opcional en formularios de propuesta y en el formulario de producto del admin, además de normalizar datos heredados en `js/app.js`.
- Implementa mensajes privados por producto en el catálogo con formulario en cada tarjeta y un nuevo panel `Mensajes` en el modal administrador (almacenamiento local en `localStorage` con clave `LTA_MESSAGES_V1`).
- Actualiza estilos en `css/styles.css` para fondo blanco, nuevos colores, mayor tamaño y centrado del título, preview grids, mini-galería, y animaciones `flow` y `floatCard` para tarjetas.

### Testing
- Levanté un servidor estático con `python -m http.server 8000` y el comando se ejecutó correctamente to serve the updated files.
- Ejecuté un script headless con Playwright para cargar `index.html` y capturar una captura de pantalla completa, lo que confirmó que la página carga y renderiza correctamente.
- No se añadieron tests unitarios automáticos en este cambio y no se ejecutaron suites de tests adicionales.
- Cambios aplicados y commit realizados (ver archivos modificados: `index.html`, `js/app.js`, `css/styles.css`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c7c6985e8832590ce16ea9a2b19c0)