### PR TITLE
Fix toast dismissal, remove sticky header, and apply Egyptian gold theme

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,16 +1,21 @@
 :root {
   color-scheme: light;
-  --bg: #111827;
-  --bg-alt: #0f172a;
+  --bg: #ffffff;
+  --bg-alt: #fdf6e8;
   --card: #ffffff;
-  --text: #0b0b0f;
-  --muted: #667085;
-  --accent: #b08968;
-  --cta: #1f7a4d;
-  --cta-dark: #17603d;
-  --border: rgba(17, 24, 39, 0.12);
-  --shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  --text: #0b0b0b;
+  --muted: #5a5a5a;
+  --gold-1: #d4af37;
+  --gold-2: #b88900;
+  --gold-3: #f2d27a;
+  --gold-4: #7a5a00;
+  --accent: var(--gold-1);
+  --cta: var(--gold-1);
+  --cta-dark: var(--gold-2);
+  --border: rgba(0, 0, 0, 0.08);
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
   --radius: 20px;
+  --transition: 180ms ease;
 }
 
 *,
@@ -24,13 +29,14 @@ body {
   font-family: "SF Pro Text", "SF Pro Display", system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--text);
-  background: #f5f5f7;
+  background: var(--bg);
   line-height: 1.6;
 }
 
 a {
   color: inherit;
   text-decoration: none;
+  transition: color var(--transition);
 }
 
 img {
@@ -45,12 +51,17 @@ textarea {
   font: inherit;
 }
 
+button {
+  transition: background var(--transition), color var(--transition),
+    border var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
 button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible,
 a:focus-visible {
-  outline: 3px solid var(--accent);
+  outline: 3px solid var(--gold-2);
   outline-offset: 2px;
 }
 
@@ -58,7 +69,7 @@ a:focus-visible {
   position: absolute;
   left: -999px;
   top: 0;
-  background: #111827;
+  background: var(--gold-4);
   color: #ffffff;
   padding: 0.75rem 1.5rem;
   border-radius: 999px;
@@ -76,17 +87,17 @@ a:focus-visible {
 }
 
 .site-header {
-  position: relative;
-  background: #ffffff;
+  position: static;
+  background: var(--bg);
   color: var(--text);
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  border-bottom: 1px solid var(--border);
 }
 
 .brand-banner {
-  background: linear-gradient(120deg, #f5f5f7, #efe9e3, #f7f2ea);
+  background: linear-gradient(120deg, #ffffff, #fff7e0, #fdf1c8);
   color: var(--text);
   text-align: center;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  border-bottom: 1px solid var(--border);
 }
 
 .brand-banner-inner {
@@ -118,7 +129,7 @@ a:focus-visible {
   font-size: 1.1rem;
   text-transform: uppercase;
   letter-spacing: 0.2em;
-  color: #6b4f2a;
+  color: var(--gold-4);
   font-weight: 700;
   justify-self: start;
 }
@@ -126,7 +137,7 @@ a:focus-visible {
 .brand-subtitle {
   margin: 0;
   font-weight: 600;
-  color: #6b4f2a;
+  color: var(--gold-4);
 }
 
 .main-nav {
@@ -141,34 +152,37 @@ a:focus-visible {
 .main-nav a {
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background var(--transition), color var(--transition);
 }
 
 .main-nav a:hover {
-  background: rgba(17, 24, 39, 0.08);
+  background: rgba(212, 175, 55, 0.2);
+  color: var(--gold-4);
 }
 
 .admin-button {
-  background: #f5f5f7;
+  background: #ffffff;
   color: var(--text);
-  border: 1px solid rgba(17, 24, 39, 0.12);
+  border: 1px solid var(--border);
   padding: 0.4rem 0.85rem;
   border-radius: 999px;
   cursor: pointer;
   justify-self: center;
   font-weight: 700;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .admin-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--shadow);
 }
 
 .contact-bar {
-  background: #111827;
+  background: #fff7e0;
   padding: 0.75rem 0;
-  color: #fff;
+  color: var(--text);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
 }
 
 .contact-bar-inner {
@@ -198,42 +212,45 @@ a:focus-visible {
   border: none;
   cursor: pointer;
   font-weight: 600;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  transition: transform var(--transition), box-shadow var(--transition),
+    background var(--transition), color var(--transition), border var(--transition);
 }
 
 .btn-primary {
-  background: linear-gradient(120deg, #1f7a4d, #3fa36a);
-  color: #fff;
+  background: linear-gradient(120deg, var(--gold-3), var(--gold-1));
+  color: #2b1c00;
 }
 
 .btn-primary:hover {
-  background: var(--cta-dark);
+  background: var(--gold-2);
+  color: #ffffff;
 }
 
 .btn-ghost {
   background: #ffffff;
-  border: 1px solid rgba(17, 24, 39, 0.12);
+  border: 1px solid var(--gold-1);
   color: var(--text);
 }
 
 .btn-whatsapp {
-  background: #0f766e;
-  color: #fff;
+  background: var(--gold-1);
+  color: #2b1c00;
+  border: 1px solid var(--gold-2);
 }
 
 .btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--shadow);
 }
 
 .btn:active {
   transform: translateY(0);
-  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.12);
 }
 
 .hero {
-  background: radial-gradient(circle at top, #1f2937, var(--bg));
-  color: #fff;
+  background: radial-gradient(circle at top, #ffffff, #fff6df);
+  color: var(--text);
   padding: 4rem 0;
 }
 
@@ -248,7 +265,7 @@ a:focus-visible {
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--accent);
+  color: var(--gold-2);
   margin-bottom: 0.5rem;
 }
 
@@ -265,11 +282,11 @@ a:focus-visible {
 }
 
 .hero-card {
-  background: rgba(255, 255, 255, 0.12);
+  background: #ffffff;
   padding: 2rem;
   border-radius: var(--radius);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.25);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
 }
 
 .hero-card ul {
@@ -278,10 +295,10 @@ a:focus-visible {
 }
 
 .trust-box {
-  background: rgba(255, 255, 255, 0.12);
+  background: #ffffff;
   padding: 1.25rem;
   border-radius: var(--radius);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--border);
 }
 
 .section {
@@ -289,7 +306,7 @@ a:focus-visible {
 }
 
 .alt-section {
-  background: #f0f1f4;
+  background: var(--bg-alt);
 }
 
 .section-head {
@@ -311,13 +328,13 @@ a:focus-visible {
   border-radius: var(--radius);
   padding: 1.5rem;
   box-shadow: var(--shadow);
-  border: 1px solid rgba(17, 24, 39, 0.06);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  border: 1px solid var(--border);
+  transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 26px 50px rgba(15, 23, 42, 0.12);
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12);
 }
 
 .course-card .price {
@@ -380,12 +397,12 @@ a:focus-visible {
   padding: 1.5rem;
   border: 1px solid var(--border);
   position: relative;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .step-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow);
 }
 
 .step-icon {
@@ -395,7 +412,7 @@ a:focus-visible {
   width: 40px;
   height: 40px;
   border-radius: 12px;
-  background: #f5f5f7;
+  background: var(--bg-alt);
   font-size: 1.2rem;
   margin-bottom: 0.75rem;
 }
@@ -437,8 +454,8 @@ a:focus-visible {
 }
 
 .dropzone.is-dragging {
-  border-color: var(--accent);
-  background: #fff7ed;
+  border-color: var(--gold-2);
+  background: #fff7e0;
 }
 
 .dropzone img {
@@ -467,7 +484,7 @@ a:focus-visible {
   border-radius: var(--radius);
   padding: 1.5rem;
   box-shadow: var(--shadow);
-  border: 1px solid rgba(17, 24, 39, 0.06);
+  border: 1px solid var(--border);
 }
 
 .tab-list {
@@ -478,18 +495,18 @@ a:focus-visible {
 }
 
 .tab {
-  background: #f5f5f7;
+  background: var(--bg-alt);
   border: none;
   border-radius: 999px;
   padding: 0.5rem 1.25rem;
   cursor: pointer;
   font-weight: 600;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background var(--transition), color var(--transition);
 }
 
 .tab[aria-selected="true"] {
-  background: #111827;
-  color: #fff;
+  background: var(--gold-2);
+  color: #ffffff;
 }
 
 .panel-grid,
@@ -509,7 +526,7 @@ a:focus-visible {
 }
 
 .timeline li {
-  background: #f5f5f7;
+  background: var(--bg-alt);
   padding: 0.75rem 1rem;
   border-radius: 12px;
   display: flex;
@@ -535,7 +552,7 @@ a:focus-visible {
   margin-top: 1rem;
   padding: 1rem;
   border-radius: 12px;
-  background: #f5f5f7;
+  background: var(--bg-alt);
 }
 
 .price-breakdown {
@@ -543,8 +560,8 @@ a:focus-visible {
   gap: 0.5rem;
   padding: 0.75rem;
   border-radius: 12px;
-  background: #f5f5f7;
-  border: 1px dashed rgba(17, 24, 39, 0.2);
+  background: var(--bg-alt);
+  border: 1px dashed rgba(0, 0, 0, 0.2);
 }
 
 .price-breakdown > div {
@@ -578,8 +595,8 @@ a:focus-visible {
 }
 
 .tag {
-  background: #f5f5f7;
-  color: #5f6b7a;
+  background: var(--bg-alt);
+  color: var(--muted);
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
   font-size: 0.8rem;
@@ -587,8 +604,8 @@ a:focus-visible {
 }
 
 .tag-alt {
-  background: #e5f4ed;
-  color: #1f7a4d;
+  background: #fff2cc;
+  color: var(--gold-4);
 }
 
 .mini-gallery {
@@ -614,9 +631,10 @@ a:focus-visible {
 }
 
 .site-footer {
-  background: var(--bg);
-  color: #fff;
+  background: #ffffff;
+  color: var(--text);
   padding: 2rem 0;
+  border-top: 1px solid var(--border);
 }
 
 .footer-grid {
@@ -640,13 +658,18 @@ a:focus-visible {
   background: #fff;
   border-radius: 14px;
   padding: 0.9rem 1rem;
-  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--shadow);
   display: flex;
   gap: 1rem;
   align-items: flex-start;
   max-width: 320px;
-  border: 1px solid rgba(17, 24, 39, 0.1);
-  z-index: 200;
+  border: 1px solid var(--border);
+  z-index: 1000;
+  pointer-events: auto;
+}
+
+.toast .btn {
+  pointer-events: auto;
 }
 
 .modal {
@@ -679,7 +702,7 @@ a:focus-visible {
   top: 1rem;
   right: 1rem;
   border: none;
-  background: #f5f5f7;
+  background: var(--bg-alt);
   border-radius: 50%;
   width: 36px;
   height: 36px;
@@ -698,7 +721,7 @@ a:focus-visible {
   gap: 1rem;
   grid-template-columns: 80px 1fr auto;
   align-items: center;
-  background: #f5f5f7;
+  background: var(--bg-alt);
   padding: 1rem;
   border-radius: 14px;
 }
@@ -708,8 +731,8 @@ a:focus-visible {
 }
 
 .admin-item.is-unread {
-  border: 1px solid rgba(176, 137, 104, 0.4);
-  background: #f7f2ea;
+  border: 1px solid rgba(184, 137, 0, 0.4);
+  background: #fff7e0;
 }
 
 .admin-item img {
@@ -743,10 +766,10 @@ a:focus-visible {
 
 .note-card {
   margin-top: 2rem;
-  background: #f5f5f7;
+  background: var(--bg-alt);
   border-radius: var(--radius);
   padding: 1.5rem;
-  border: 1px solid rgba(17, 24, 39, 0.12);
+  border: 1px solid var(--border);
   font-weight: 600;
 }
 
@@ -765,7 +788,7 @@ a:focus-visible {
   background: #fff;
   border-radius: 999px;
   padding: 0.4rem 0;
-  border: 1px dashed rgba(17, 24, 39, 0.15);
+  border: 1px dashed rgba(0, 0, 0, 0.15);
   margin: 1rem 0 2rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -467,12 +467,12 @@
     </div>
   </footer>
 
-  <div id="notificationToast" class="toast" role="status" aria-live="polite" hidden>
+  <div id="notificationToast" class="toast" role="status" aria-live="polite" data-toast="welcome" hidden>
     <div>
       <h4>Notificación</h4>
       <p id="notificationMessage"></p>
     </div>
-    <button class="btn btn-ghost" id="closeNotification" type="button">Cerrar</button>
+    <button class="btn btn-ghost" id="closeNotification" type="button" data-toast-close="1" aria-label="Cerrar notificación">Cerrar</button>
   </div>
 
   <div id="adminModal" class="modal" aria-hidden="true">


### PR DESCRIPTION
### Motivation
- The toast close button was unreliable across devices and could be blocked by overlays or missing event handlers, so it must close instantly on click/tap/keyboard and persist as dismissed for 24h.
- The header was behaving as sticky/fixed in the layout causing it to follow scroll, which must be reverted to normal document flow.
- The global branding used blue/green tones and dark backgrounds and needs to change to a premium Egyptian-gold palette on white surfaces with smooth transitions.

### Description
- Implemented robust toast dismissal: added `data-toast="welcome"` on the toast and `data-toast-close="1"` on the button in `index.html`, and added delegated listeners in `js/app.js` using `document.addEventListener('click',..., {capture:true})`, `touchstart` (passive + capture) and `keydown` (capture) to support mouse, touch and keyboard; `dismissNotification()` removes the toast and saves a 24h dismissal timestamp under `LTA_NOTIFICATION_DISMISSED_AT_V1`.
- Defensive JS guards were added so missing elements do not throw, and `showNotification()` respects the enabled flag and 24h dismissed state in `js/app.js`.
- Reverted header behavior to normal flow by setting `.site-header { position: static; }` and removing top/z-index forcing; updated toast CSS to ensure `pointer-events: auto`, higher `z-index`, and the toast button explicitly allows pointer events in `css/styles.css`.
- Reworked theme tokens in `css/styles.css` by adding `:root` gold variables (`--gold-1`..`--gold-4`), `--bg: #ffffff`, `--text`, `--border`, `--shadow`, `--transition`, and updated main selectors (header, buttons, links, cards, tabs, footer, toast) to use the Egyptian-gold palette and smoother transitions.

### Testing
- Launched a local static server with `python -m http.server 8000` and confirmed the site served without errors. (succeeded)
- Ran an automated Playwright script that opened `http://127.0.0.1:8000/index.html` and captured a full-page screenshot to validate layout and styles were applied. (succeeded)
- Basic smoke: exercised toast dismissal via the delegated handlers in the browser run and confirmed the script removed the toast without errors. (succeeded)
- No unit tests were present; changes are limited to UI/UX and validated by the above automated browser check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d68a292d883258b5ad84edfbac23e)