### PR TITLE
Eliminar juego, reforzar paleta dorada y ampliar catálogo (venta/renta + cursos)

### DIFF
--- a/courses.html
+++ b/courses.html
@@ -4,10 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Cursos</title>
-<!-- build-id: GOLDLOCK_20250308_1200 -->
-<link rel="stylesheet" href="css/styles.css?v=20250308-1200">
+<!-- build-id: GOLD_BASE_KEEP_UI_20250119_0900 -->
+<link rel="stylesheet" href="css/styles.css?v=20250119-0900">
 </head>
-<body data-build="GOLDLOCK_20250308_1200">
+<body data-build="GOLD_BASE_KEEP_UI_20250119_0900">
 <header>
   <div class="container">
     <h1>Cursos</h1>
@@ -70,7 +70,7 @@
   <a href="https://wa.me/525610885357" class="whatsapp">WhatsApp: +52 56 1088 5357</a>
   <p>&copy; 2025 Fisuras Matemáticas</p>
 </footer>
-<script src="js/notify.js?v=20250308-1200"></script>
-<script src="js/scripts.js?v=20250308-1200"></script>
+<script src="js/notify.js?v=20250119-0900"></script>
+<script src="js/scripts.js?v=20250119-0900"></script>
 </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -641,38 +641,6 @@ a:focus-visible {
   gap: 0.3rem;
 }
 
-.math-game {
-  display: grid;
-  gap: 1rem;
-}
-
-.math-question {
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--gold-4);
-  padding: 0.75rem 1rem;
-  border-radius: 12px;
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-}
-
-.math-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.game-score {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  font-weight: 600;
-}
-
 .panel-header {
   display: flex;
   align-items: center;

--- a/data/courses.json
+++ b/data/courses.json
@@ -1,17 +1,25 @@
 [
   {
-    "id":"algebra",
-    "nombre":"Álgebra",
-    "descripcion":"Operaciones con expresiones algebraicas y ecuaciones.",
-    "precio":300,
-    "precio_descuento":240,
-    "fecha_inicio":"2025-06-02",
-    "fecha_fin":"2025-06-29",
-    "dias_horarios":[
-      {"dia":"Lunes","hora_inicio":"18:00","hora_fin":"20:00"},
-      {"dia":"Miércoles","hora_inicio":"18:00","hora_fin":"20:00"}
+    "id": "algebra",
+    "nombre": "Álgebra",
+    "descripcion": "Operaciones con expresiones algebraicas y ecuaciones.",
+    "precio": 2400,
+    "precio_descuento": 2000,
+    "fecha_inicio": "2025-01-19",
+    "fecha_fin": "2025-02-19",
+    "dias_horarios": [
+      {
+        "dia": "Lunes",
+        "hora_inicio": "18:00",
+        "hora_fin": "20:00"
+      },
+      {
+        "dia": "Miércoles",
+        "hora_inicio": "18:00",
+        "hora_fin": "20:00"
+      }
     ],
-    "temario":[
+    "temario": [
       "Operaciones con números reales",
       "Potencias y radicales",
       "Expresiones algebraicas",
@@ -33,23 +41,31 @@
       "Vectores",
       "Resolución de problemas"
     ],
-    "grupos":[],
-    "inscripciones":[],
-    "agendas_llamada":[]
+    "grupos": [],
+    "inscripciones": [],
+    "agendas_llamada": []
   },
   {
-    "id":"calculo",
-    "nombre":"Cálculo",
-    "descripcion":"Límites, derivadas e integrales.",
-    "precio":300,
-    "precio_descuento":240,
-    "fecha_inicio":"2025-06-03",
-    "fecha_fin":"2025-06-30",
-    "dias_horarios":[
-      {"dia":"Martes","hora_inicio":"19:00","hora_fin":"21:00"},
-      {"dia":"Jueves","hora_inicio":"19:00","hora_fin":"21:00"}
+    "id": "calculo",
+    "nombre": "Cálculo",
+    "descripcion": "Límites, derivadas e integrales.",
+    "precio": 2400,
+    "precio_descuento": 2000,
+    "fecha_inicio": "2025-01-19",
+    "fecha_fin": "2025-02-19",
+    "dias_horarios": [
+      {
+        "dia": "Martes",
+        "hora_inicio": "19:00",
+        "hora_fin": "21:00"
+      },
+      {
+        "dia": "Jueves",
+        "hora_inicio": "19:00",
+        "hora_fin": "21:00"
+      }
     ],
-    "temario":[
+    "temario": [
       "Conjuntos numéricos",
       "Funciones reales",
       "Límites",
@@ -71,23 +87,31 @@
       "Campos vectoriales",
       "Aplicaciones en física"
     ],
-    "grupos":[],
-    "inscripciones":[],
-    "agendas_llamada":[]
+    "grupos": [],
+    "inscripciones": [],
+    "agendas_llamada": []
   },
   {
-    "id":"geometria",
-    "nombre":"Geometría",
-    "descripcion":"Figuras, área y volumen.",
-    "precio":300,
-    "precio_descuento":240,
-    "fecha_inicio":"2025-06-04",
-    "fecha_fin":"2025-07-01",
-    "dias_horarios":[
-      {"dia":"Lunes","hora_inicio":"16:00","hora_fin":"18:00"},
-      {"dia":"Jueves","hora_inicio":"16:00","hora_fin":"18:00"}
+    "id": "geometria",
+    "nombre": "Geometría",
+    "descripcion": "Figuras, área y volumen.",
+    "precio": 2400,
+    "precio_descuento": 2000,
+    "fecha_inicio": "2025-01-19",
+    "fecha_fin": "2025-02-19",
+    "dias_horarios": [
+      {
+        "dia": "Lunes",
+        "hora_inicio": "16:00",
+        "hora_fin": "18:00"
+      },
+      {
+        "dia": "Jueves",
+        "hora_inicio": "16:00",
+        "hora_fin": "18:00"
+      }
     ],
-    "temario":[
+    "temario": [
       "Puntos y rectas",
       "Ángulos",
       "Triángulos",
@@ -109,23 +133,31 @@
       "Trigonometría básica",
       "Geometría analítica"
     ],
-    "grupos":[],
-    "inscripciones":[],
-    "agendas_llamada":[]
+    "grupos": [],
+    "inscripciones": [],
+    "agendas_llamada": []
   },
   {
-    "id":"trigonometria",
-    "nombre":"Trigonometría",
-    "descripcion":"Funciones trigonométricas y sus aplicaciones.",
-    "precio":300,
-    "precio_descuento":240,
-    "fecha_inicio":"2025-06-05",
-    "fecha_fin":"2025-07-02",
-    "dias_horarios":[
-      {"dia":"Martes","hora_inicio":"18:00","hora_fin":"20:00"},
-      {"dia":"Viernes","hora_inicio":"18:00","hora_fin":"20:00"}
+    "id": "trigonometria",
+    "nombre": "Trigonometría",
+    "descripcion": "Funciones trigonométricas y sus aplicaciones.",
+    "precio": 2400,
+    "precio_descuento": 2000,
+    "fecha_inicio": "2025-01-19",
+    "fecha_fin": "2025-02-19",
+    "dias_horarios": [
+      {
+        "dia": "Martes",
+        "hora_inicio": "18:00",
+        "hora_fin": "20:00"
+      },
+      {
+        "dia": "Viernes",
+        "hora_inicio": "18:00",
+        "hora_fin": "20:00"
+      }
     ],
-    "temario":[
+    "temario": [
       "Medición de ángulos",
       "Radianes",
       "Razones trigonométricas",
@@ -147,23 +179,31 @@
       "Fase y amplitud",
       "Problemas de altura"
     ],
-    "grupos":[],
-    "inscripciones":[],
-    "agendas_llamada":[]
+    "grupos": [],
+    "inscripciones": [],
+    "agendas_llamada": []
   },
   {
-    "id":"probabilidad",
-    "nombre":"Probabilidad",
-    "descripcion":"Análisis de eventos aleatorios.",
-    "precio":300,
-    "precio_descuento":240,
-    "fecha_inicio":"2025-06-06",
-    "fecha_fin":"2025-07-03",
-    "dias_horarios":[
-      {"dia":"Miércoles","hora_inicio":"17:00","hora_fin":"19:00"},
-      {"dia":"Sábado","hora_inicio":"09:00","hora_fin":"11:00"}
+    "id": "probabilidad",
+    "nombre": "Probabilidad",
+    "descripcion": "Análisis de eventos aleatorios.",
+    "precio": 2400,
+    "precio_descuento": 2000,
+    "fecha_inicio": "2025-01-19",
+    "fecha_fin": "2025-02-19",
+    "dias_horarios": [
+      {
+        "dia": "Miércoles",
+        "hora_inicio": "17:00",
+        "hora_fin": "19:00"
+      },
+      {
+        "dia": "Sábado",
+        "hora_inicio": "09:00",
+        "hora_fin": "11:00"
+      }
     ],
-    "temario":[
+    "temario": [
       "Espacios muestrales",
       "Eventos",
       "Combinatoria",
@@ -185,23 +225,31 @@
       "Procesos estocásticos",
       "Simulación"
     ],
-    "grupos":[],
-    "inscripciones":[],
-    "agendas_llamada":[]
+    "grupos": [],
+    "inscripciones": [],
+    "agendas_llamada": []
   },
   {
-    "id":"estadistica",
-    "nombre":"Estadística",
-    "descripcion":"Descripción y análisis de datos.",
-    "precio":300,
-    "precio_descuento":240,
-    "fecha_inicio":"2025-06-07",
-    "fecha_fin":"2025-07-04",
-    "dias_horarios":[
-      {"dia":"Jueves","hora_inicio":"17:00","hora_fin":"19:00"},
-      {"dia":"Sábado","hora_inicio":"12:00","hora_fin":"14:00"}
+    "id": "estadistica",
+    "nombre": "Estadística",
+    "descripcion": "Descripción y análisis de datos.",
+    "precio": 2400,
+    "precio_descuento": 2000,
+    "fecha_inicio": "2025-01-19",
+    "fecha_fin": "2025-02-19",
+    "dias_horarios": [
+      {
+        "dia": "Jueves",
+        "hora_inicio": "17:00",
+        "hora_fin": "19:00"
+      },
+      {
+        "dia": "Sábado",
+        "hora_inicio": "12:00",
+        "hora_fin": "14:00"
+      }
     ],
-    "temario":[
+    "temario": [
       "Tipos de datos",
       "Medidas de tendencia central",
       "Medidas de dispersión",
@@ -223,23 +271,31 @@
       "Bootstrap",
       "Minería de datos"
     ],
-    "grupos":[],
-    "inscripciones":[],
-    "agendas_llamada":[]
+    "grupos": [],
+    "inscripciones": [],
+    "agendas_llamada": []
   },
   {
-    "id":"fisica1",
-    "nombre":"Física 1",
-    "descripcion":"Mecánica clásica y leyes del movimiento.",
-    "precio":300,
-    "precio_descuento":240,
-    "fecha_inicio":"2025-06-08",
-    "fecha_fin":"2025-07-05",
-    "dias_horarios":[
-      {"dia":"Lunes","hora_inicio":"07:00","hora_fin":"09:00"},
-      {"dia":"Miércoles","hora_inicio":"07:00","hora_fin":"09:00"}
+    "id": "fisica1",
+    "nombre": "Física 1",
+    "descripcion": "Mecánica clásica y leyes del movimiento.",
+    "precio": 2400,
+    "precio_descuento": 2000,
+    "fecha_inicio": "2025-01-19",
+    "fecha_fin": "2025-02-19",
+    "dias_horarios": [
+      {
+        "dia": "Lunes",
+        "hora_inicio": "07:00",
+        "hora_fin": "09:00"
+      },
+      {
+        "dia": "Miércoles",
+        "hora_inicio": "07:00",
+        "hora_fin": "09:00"
+      }
     ],
-    "temario":[
+    "temario": [
       "Cinemática",
       "Vectores",
       "Movimiento rectilíneo",
@@ -261,23 +317,31 @@
       "Movimiento planetario",
       "Colisiones elásticas"
     ],
-    "grupos":[],
-    "inscripciones":[],
-    "agendas_llamada":[]
+    "grupos": [],
+    "inscripciones": [],
+    "agendas_llamada": []
   },
   {
-    "id":"fisica2",
-    "nombre":"Física 2",
-    "descripcion":"Electricidad y magnetismo.",
-    "precio":300,
-    "precio_descuento":240,
-    "fecha_inicio":"2025-06-09",
-    "fecha_fin":"2025-07-06",
-    "dias_horarios":[
-      {"dia":"Martes","hora_inicio":"07:00","hora_fin":"09:00"},
-      {"dia":"Jueves","hora_inicio":"07:00","hora_fin":"09:00"}
+    "id": "fisica2",
+    "nombre": "Física 2",
+    "descripcion": "Electricidad y magnetismo.",
+    "precio": 2400,
+    "precio_descuento": 2000,
+    "fecha_inicio": "2025-01-19",
+    "fecha_fin": "2025-02-19",
+    "dias_horarios": [
+      {
+        "dia": "Martes",
+        "hora_inicio": "07:00",
+        "hora_fin": "09:00"
+      },
+      {
+        "dia": "Jueves",
+        "hora_inicio": "07:00",
+        "hora_fin": "09:00"
+      }
     ],
-    "temario":[
+    "temario": [
       "Carga eléctrica",
       "Ley de Coulomb",
       "Campo eléctrico",
@@ -299,8 +363,8 @@
       "Óptica",
       "Circuitos de corriente alterna"
     ],
-    "grupos":[],
-    "inscripciones":[],
-    "agendas_llamada":[]
+    "grupos": [],
+    "inscripciones": [],
+    "agendas_llamada": []
   }
 ]

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LA TIENDA DE ALBERTO</title>
-  <!-- build-id: GOLDLOCK_20250308_1200 -->
-  <link rel="stylesheet" href="css/styles.css?v=20250308-1200">
+  <!-- build-id: GOLD_BASE_KEEP_UI_20250119_0900 -->
+  <link rel="stylesheet" href="css/styles.css?v=20250119-0900">
 </head>
-<body data-build="GOLDLOCK_20250308_1200">
+<body data-build="GOLD_BASE_KEEP_UI_20250119_0900">
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
   <header class="site-header">
     <div class="brand-banner">
@@ -228,21 +228,21 @@
           <article class="card course-card reveal">
             <h3>Álgebra</h3>
             <p>8 sesiones de 1 hora</p>
-            <p class="muted">Inicio: 15 de marzo · Fin: 15 de abril</p>
+            <p class="muted">Inicio: 19 de enero · Fin: 19 de febrero</p>
             <p class="price">$2400 MXN</p>
             <button class="btn btn-whatsapp" data-course="Álgebra">Solicitar por WhatsApp</button>
           </article>
           <article class="card course-card reveal">
             <h3>Cálculo Diferencial</h3>
             <p>8 sesiones de 1 hora</p>
-            <p class="muted">Inicio: 2 de abril · Fin: 2 de mayo</p>
+            <p class="muted">Inicio: 19 de enero · Fin: 19 de febrero</p>
             <p class="price">$2400 MXN</p>
             <button class="btn btn-whatsapp" data-course="Cálculo Diferencial">Solicitar por WhatsApp</button>
           </article>
           <article class="card course-card reveal">
             <h3>Cálculo Integral</h3>
             <p>8 sesiones de 1 hora</p>
-            <p class="muted">Inicio: 20 de abril · Fin: 20 de mayo</p>
+            <p class="muted">Inicio: 19 de enero · Fin: 19 de febrero</p>
             <p class="price">$2400 MXN</p>
             <button class="btn btn-whatsapp" data-course="Cálculo Integral">Solicitar por WhatsApp</button>
           </article>
@@ -405,51 +405,18 @@
         </div>
         <div class="tabs" data-tabs>
           <div class="tab-list" role="tablist" aria-label="Secciones interactivas">
-            <button class="tab" role="tab" aria-selected="true" aria-controls="tab-juego" id="tab-juego-btn">Juego matemático</button>
-            <button class="tab" role="tab" aria-selected="false" aria-controls="tab-proximos" id="tab-proximos-btn">Próximos cursos</button>
+            <button class="tab" role="tab" aria-selected="true" aria-controls="tab-proximos" id="tab-proximos-btn">Próximos cursos</button>
             <button class="tab" role="tab" aria-selected="false" aria-controls="tab-estudiantes" id="tab-estudiantes-btn">Estudiantes</button>
             <button class="tab" role="tab" aria-selected="false" aria-controls="tab-contacto" id="tab-contacto-btn">Contacto</button>
           </div>
-          <div id="tab-juego" class="tab-panel" role="tabpanel" aria-labelledby="tab-juego-btn">
-            <div class="panel-grid">
-              <div class="card reveal">
-                <h3>Juego rápido de matemáticas</h3>
-                <p>Resuelve operaciones para entrenar tu mente antes de clase.</p>
-                <form id="mathGameForm" class="math-game">
-                  <div class="math-question" id="mathGameQuestion" aria-live="polite"></div>
-                  <label class="field">
-                    <span>Respuesta</span>
-                    <input type="number" id="mathGameAnswer" required inputmode="numeric">
-                  </label>
-                  <div class="math-actions">
-                    <button class="btn btn-primary" type="submit">Comprobar</button>
-                    <button class="btn btn-ghost" id="mathGameNew" type="button">Nuevo reto</button>
-                  </div>
-                  <p id="mathGameFeedback" class="muted" aria-live="polite"></p>
-                </form>
-                <div class="game-score">
-                  <span>Racha:</span>
-                  <strong id="mathGameScore">0</strong>
-                </div>
-              </div>
-              <div class="card reveal">
-                <h3>¿Por qué jugar?</h3>
-                <ul>
-                  <li>Mejora velocidad mental.</li>
-                  <li>Refuerza operaciones básicas.</li>
-                  <li>Te prepara para los cursos de cálculo y álgebra.</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-          <div id="tab-proximos" class="tab-panel" role="tabpanel" aria-labelledby="tab-proximos-btn" hidden>
+          <div id="tab-proximos" class="tab-panel" role="tabpanel" aria-labelledby="tab-proximos-btn">
             <div class="panel-grid">
               <div class="upcoming-card card reveal">
                 <h3>Próximos cursos</h3>
                 <ul class="timeline">
-                  <li><strong>Álgebra intensiva</strong><span>Inicio: 15 de marzo · Fin: 15 de abril</span></li>
-                  <li><strong>Cálculo diferencial</strong><span>Inicio: 2 de abril · Fin: 2 de mayo</span></li>
-                  <li><strong>Cálculo integral</strong><span>Inicio: 20 de abril · Fin: 20 de mayo</span></li>
+                  <li><strong>Álgebra intensiva</strong><span>Inicio: 19 de enero · Fin: 19 de febrero</span></li>
+                  <li><strong>Cálculo diferencial</strong><span>Inicio: 19 de enero · Fin: 19 de febrero</span></li>
+                  <li><strong>Cálculo integral</strong><span>Inicio: 19 de enero · Fin: 19 de febrero</span></li>
                 </ul>
                 <p class="muted">Solicita tu lugar con anticipación.</p>
               </div>
@@ -753,6 +720,6 @@
     </div>
   </div>
 
-  <script src="js/scripts.js?v=20250308-1200"></script>
+  <script src="js/scripts.js?v=20250119-0900"></script>
 </body>
 </html>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -106,6 +106,7 @@ const CATEGORIES = [
       { id: "celulares", name: "Celulares" },
       { id: "tablets", name: "Tablets" },
       { id: "laptops", name: "Laptops" },
+      { id: "computo", name: "Cómputo" },
       { id: "desktop", name: "Computadoras de escritorio" },
       { id: "monitores", name: "Monitores" },
       { id: "consolas", name: "Consolas" },
@@ -269,12 +270,6 @@ const studentPreview = document.getElementById("studentPreview");
 
 const contactForm = document.getElementById("contactForm");
 const contactStatus = document.getElementById("contactStatus");
-const mathGameForm = document.getElementById("mathGameForm");
-const mathGameQuestion = document.getElementById("mathGameQuestion");
-const mathGameAnswer = document.getElementById("mathGameAnswer");
-const mathGameFeedback = document.getElementById("mathGameFeedback");
-const mathGameScore = document.getElementById("mathGameScore");
-const mathGameNew = document.getElementById("mathGameNew");
 const categorySelect = document.getElementById("categorySelect");
 const subcategorySelect = document.getElementById("subcategorySelect");
 const childcategorySelect = document.getElementById("childcategorySelect");
@@ -880,6 +875,7 @@ const defaultProducts = () => [
     categoryId: "inmuebles",
     subcategoryId: "renta",
     childId: "renta-departamentos",
+    operation: "renta",
     type: "Producto",
     status: "publicado",
     isProtected: false,
@@ -899,6 +895,7 @@ const defaultProducts = () => [
     categoryId: "inmuebles",
     subcategoryId: "renta",
     childId: "renta-locales",
+    operation: "renta",
     type: "Producto",
     status: "publicado",
     isProtected: false,
@@ -1025,7 +1022,7 @@ const defaultProducts = () => [
     id: generateId(),
     title: "Renta de sonido para eventos (5 horas)",
     description:
-      "Sonido para fiestas y eventos sociales por 5 horas. Ideal para reuniones, cumpleaños y celebraciones. Te apoyamos para que tu evento se escuche con claridad y buena potencia.",
+      "Renta de sonido para fiestas y eventos por 5 horas. Ideal para reuniones, cumpleaños y celebraciones. Coordinamos contigo para que tu evento se escuche claro y con buena presencia.",
     price: 5000,
     priceMXN: 5000,
     images: [demoImage("Sonido")],
@@ -1033,6 +1030,7 @@ const defaultProducts = () => [
     categoryId: "servicios",
     subcategoryId: "eventos",
     childId: "",
+    operation: "renta",
     type: "Servicio",
     status: "publicado",
     isProtected: false,
@@ -1083,7 +1081,7 @@ const defaultProducts = () => [
     id: generateId(),
     title: "Renta de sonido para eventos (5 horas)",
     description:
-      "Renta de sonido para fiestas y eventos por 5 horas. Ideal para celebraciones y reuniones. Te notificamos y coordinamos contigo para que todo suene claro y con buena presencia.",
+      "Renta de sonido para fiestas y eventos por 5 horas. Ideal para reuniones, cumpleaños y celebraciones. Coordinamos contigo para que tu evento se escuche claro y con buena presencia.",
     price: 5000,
     priceMXN: 5000,
     images: [demoImage("Sonido")],
@@ -1104,8 +1102,8 @@ const defaultProducts = () => [
     id: generateId(),
     title: "Ecuaciones diferenciales",
     description: "Curso enfocado en resolución de ecuaciones diferenciales con ejemplos guiados.",
-    price: null,
-    priceMXN: null,
+    price: 2400,
+    priceMXN: 2400,
     images: [demoImage("Ecuaciones")],
     category: "Cursos",
     categoryId: "cursos",
@@ -1123,8 +1121,8 @@ const defaultProducts = () => [
     id: generateId(),
     title: "Álgebra lineal",
     description: "Matrices, vectores y espacios vectoriales con práctica aplicada.",
-    price: null,
-    priceMXN: null,
+    price: 2400,
+    priceMXN: 2400,
     images: [demoImage("Álgebra")],
     category: "Cursos",
     categoryId: "cursos",
@@ -1161,8 +1159,8 @@ const defaultProducts = () => [
     id: generateId(),
     title: "Aprende a sumar, restar, multiplicar y dividir",
     description: "Curso base para dominar operaciones fundamentales.",
-    price: null,
-    priceMXN: null,
+    price: 2400,
+    priceMXN: 2400,
     images: [demoImage("Operaciones")],
     category: "Cursos",
     categoryId: "cursos",
@@ -1501,26 +1499,15 @@ const renderProducts = () => {
     categoryTag.className = "tag tag-alt";
     categoryTag.textContent = getCategoryLabel(product);
     const operationTag = document.createElement("span");
-    operationTag.className = "tag";
+    operationTag.className = "tag tag-highlight";
     operationTag.textContent = formatOperation(product.operation);
     meta.append(typeTag, operationTag, categoryTag);
-    const operationTag = document.createElement("span");
-    operationTag.className = "tag";
-    operationTag.textContent = formatOperation(product.operation);
-    meta.append(operationTag);
     const subcategoryLabel = getSubcategoryLabel(product);
     if (subcategoryLabel) {
       const subTag = document.createElement("span");
       subTag.className = "tag";
       subTag.textContent = subcategoryLabel;
       meta.append(subTag);
-    }
-    const childLabel = getChildLabel(product);
-    if (childLabel) {
-      const childTag = document.createElement("span");
-      childTag.className = "tag";
-      childTag.textContent = childLabel;
-      meta.append(childTag);
     }
     const childLabel = getChildLabel(product);
     if (childLabel) {
@@ -2738,53 +2725,6 @@ const setupContactForm = () => {
   });
 };
 
-const setupMathGame = () => {
-  if (
-    !mathGameForm ||
-    !mathGameQuestion ||
-    !mathGameAnswer ||
-    !mathGameFeedback ||
-    !mathGameScore ||
-    !mathGameNew
-  ) {
-    return;
-  }
-  let currentAnswer = 0;
-  let streak = 0;
-  const operations = [
-    { symbol: "+", fn: (a, b) => a + b },
-    { symbol: "−", fn: (a, b) => a - b },
-    { symbol: "×", fn: (a, b) => a * b },
-  ];
-  const newChallenge = () => {
-    const a = Math.floor(Math.random() * 20) + 1;
-    const b = Math.floor(Math.random() * 12) + 1;
-    const operation = operations[Math.floor(Math.random() * operations.length)];
-    const safeA = operation.symbol === "−" && a < b ? b : a;
-    const safeB = operation.symbol === "−" && a < b ? a : b;
-    currentAnswer = operation.fn(safeA, safeB);
-    mathGameQuestion.textContent = `${safeA} ${operation.symbol} ${safeB} = ?`;
-    mathGameAnswer.value = "";
-    mathGameAnswer.focus();
-    mathGameFeedback.textContent = "";
-  };
-  mathGameForm.addEventListener("submit", (event) => {
-    event.preventDefault();
-    const value = Number(mathGameAnswer.value);
-    if (Number.isFinite(value) && value === currentAnswer) {
-      streak += 1;
-      mathGameFeedback.textContent = "¡Correcto! Sigue con el siguiente reto.";
-    } else {
-      streak = 0;
-      mathGameFeedback.textContent = `Respuesta incorrecta. La respuesta era ${currentAnswer}.`;
-    }
-    mathGameScore.textContent = streak.toString();
-    newChallenge();
-  });
-  mathGameNew.addEventListener("click", newChallenge);
-  newChallenge();
-};
-
 const initCoursesPage = () => {
   const coursesContainer = document.getElementById("courses");
   if (!coursesContainer) return;
@@ -3352,7 +3292,6 @@ const init = () => {
   setupProposalEvents();
   setupProtectedAccess();
   setupAboutForm();
-  setupMathGame();
   initCoursesPage();
   initializeNotificationForm();
   renderCatalogMenu();


### PR DESCRIPTION
### Motivation

- Mantener la apariencia dorada + blanco y la barra de categorías existente mientras se eliminan elementos prohibidos y se añaden soporte de renta/venta en el catálogo.
- Evitar regresiones de estilo por archivos duplicados y asegurar que el deploy cargue la fuente de verdad mediante cache-busting y build-id visibles.
- Integrar cursos y el servicio de renta de sonido solicitados sin eliminar otros ítems ni cambiar la estructura UI principal.
- Sustituir solo lo necesario (cambios quirúrgicos) removiendo por completo cualquier lógica/HTML/CSS del juego.

### Description

- Eliminé la sección del juego (HTML), sus estilos y la lógica de inicialización en JS, manteniendo el mecanismo anti-reaparición (`removeRestrictedElements`).
- Añadí/forcé el campo `operation` en los ítems relevantes (p. ej. inmuebles y el servicio de sonido) y mostré la operación con un badge destacado dorado en las tarjetas.
- Actualicé cursos y su seed JSON (`data/courses.json`) para poner precios a $2400 MXN, descuentos a $2000 MXN y fechas de inicio/fin al `2025-01-19 / 2025-02-19`, y añadí el servicio “Renta de sonido para eventos (5 horas)” por $5,000 MXN con la descripción acordada.
- Añadí build-id y cache-busting `?v=20250119-0900` en `index.html` y `courses.html`, y toqué `css/styles.css`, `js/scripts.js`, `index.html`, `courses.html`, y `data/courses.json` (archivos exactos listados abajo).

### Testing

- Ejecuté una búsqueda global automatizada por palabras prohibidas (juego/game/quiz/reto/canvas/etc.) y confirmé que no quedan referencias activas al juego; la búsqueda mostró que las referencias fueron eliminadas.
- Serví el sitio localmente con un servidor HTTP y capturé una captura de pantalla con Playwright para validar render básico de la página principal; la captura se generó correctamente.
- Verifiqué que `data/courses.json` contiene las fechas y precios actualizados y que los assets principales (`css/styles.css` y `js/scripts.js`) se cargan con el nuevo `?v=` (cache-busting) y build-id.

Files modified:
- `index.html`
- `courses.html`
- `css/styles.css`
- `js/scripts.js`
- `data/courses.json`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e0eadbe408325bdab348dbdd3026f)