### PR TITLE
Arreglar editar en admin; agregar lupa fullscreen, mapas (Leaflet), expiración y música

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -31,7 +31,7 @@ if(isset($_SESSION['auth'])){
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Mensajes</title>
 <!-- build-id: GOLD_RENT_KEEPUI_20251226_0530 -->
-<link rel="stylesheet" href="css/styles.css?v=20251226-1601">
+<link rel="stylesheet" href="css/styles.css?v=20250214-1530">
 </head>
 <body data-build="GOLD_RENT_KEEPUI_20251226_0530">
 <header class="sticky">

--- a/assets/audio/README.md
+++ b/assets/audio/README.md
@@ -1,0 +1,4 @@
+Coloca aquí el archivo de música navideña con el nombre `navidad.mp3`.
+
+- Formato recomendado: MP3.
+- El reproductor se carga en `index.html` y se intenta reproducir una vez por carga.

--- a/courses.html
+++ b/courses.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Cursos</title>
 <!-- build-id: GOLD_RENT_KEEPUI_20251226_0530 -->
-<link rel="stylesheet" href="css/styles.css?v=20251226-1601">
+<link rel="stylesheet" href="css/styles.css?v=20250214-1530">
 </head>
 <body data-build="GOLD_RENT_KEEPUI_20251226_0530">
 <header>
@@ -70,7 +70,7 @@
   <a href="https://wa.me/525610885357" class="whatsapp">WhatsApp: +52 56 1088 5357</a>
   <p>&copy; 2025 Fisuras Matemáticas</p>
 </footer>
-<script src="js/notify.js?v=20251226-1601"></script>
-<script src="js/scripts.js?v=20251226-1601"></script>
+<script src="js/notify.js?v=20250214-1530"></script>
+<script src="js/scripts.js?v=20250214-1530"></script>
 </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -915,6 +915,32 @@ a:focus-visible {
   background: var(--gold-2);
 }
 
+.zoom-lens {
+  position: fixed;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  border: 2px solid rgba(184, 137, 0, 0.7);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.25);
+  background-repeat: no-repeat;
+  background-size: 400%;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(-50%, -50%);
+  transition: opacity 0.15s ease;
+  z-index: 1200;
+}
+
+.zoom-lens.is-active {
+  opacity: 1;
+}
+
+@media (hover: none), (pointer: coarse) {
+  .zoom-lens {
+    display: none;
+  }
+}
+
 .site-footer {
   background: #ffffff;
   color: var(--text);
@@ -1037,8 +1063,8 @@ a:focus-visible {
 }
 
 .admin-item img {
-  width: 96px;
-  height: 96px;
+  width: 120px;
+  height: 120px;
   border-radius: 12px;
   object-fit: cover;
   cursor: zoom-in;
@@ -1215,31 +1241,31 @@ a:focus-visible {
 
 .lightbox-content {
   position: relative;
-  background: #ffffff;
-  border-radius: var(--radius);
-  padding: 1rem;
-  max-width: min(920px, 95vw);
-  max-height: 90vh;
+  width: 100vw;
+  height: 100vh;
+  background: transparent;
+  padding: 3.5rem 1.5rem 2rem;
   display: grid;
   place-items: center;
 }
 
 .lightbox-content img {
-  max-width: 100%;
-  max-height: 70vh;
-  border-radius: 12px;
+  max-width: 100vw;
+  max-height: 100vh;
+  border-radius: 16px;
+  object-fit: contain;
 }
 
 .lightbox-close {
   position: absolute;
-  top: 0.6rem;
-  right: 0.6rem;
+  top: 1.2rem;
+  right: 1.2rem;
   border: none;
   background: var(--bg-alt);
   border-radius: 999px;
-  width: 36px;
-  height: 36px;
-  font-size: 1.5rem;
+  width: 44px;
+  height: 44px;
+  font-size: 1.8rem;
   cursor: pointer;
 }
 
@@ -1249,6 +1275,47 @@ a:focus-visible {
   border-radius: 12px;
   border: 1px dashed var(--border);
   background: var(--bg-alt);
+}
+
+.map-embed {
+  width: 100%;
+  height: 200px;
+  border-radius: 12px;
+  margin-bottom: 0.5rem;
+  overflow: hidden;
+}
+
+.map-panel {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.map-preview {
+  width: 100%;
+  height: 240px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: #f8f8f8;
+  overflow: hidden;
+}
+
+.location-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.music-toggle {
+  position: fixed;
+  left: 1rem;
+  bottom: 1rem;
+  z-index: 900;
+  background: #ffffff;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
 }
 
 .map-block a {

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LA TIENDA DE ALBERTO</title>
   <!-- build-id: GOLD_RENT_KEEPUI_20251226_0759 -->
-  <link rel="stylesheet" href="css/styles.css?v=20251227-0044">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="css/styles.css?v=20250214-1530">
 </head>
 <body data-build="GOLD_RENT_KEEPUI_20251226_0759">
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -166,6 +167,17 @@
               <span>Dirección o zona aproximada (opcional)</span>
               <input type="text" id="proposalAddress" placeholder="Ej. Colonia Roma, CDMX">
             </label>
+            <div class="location-actions">
+              <button class="btn btn-ghost" id="proposalMapSearch" type="button">Buscar en mapa</button>
+              <label class="checkbox">
+                <input type="checkbox" id="proposalMapManual">
+                <span>Colocar pin manualmente</span>
+              </label>
+            </div>
+            <div class="map-panel">
+              <div class="map-preview" id="proposalMap" aria-label="Mapa de ubicación"></div>
+              <p class="muted small" id="proposalMapStatus">La ubicación puede ser aproximada. La publicación se revisa antes de mostrarse.</p>
+            </div>
             <label class="checkbox">
               <input type="checkbox" id="proposalMapRequest">
               <span>Permitir mostrar mapa (sujeto a aprobación)</span>
@@ -783,14 +795,15 @@
         </form>
       </div>
       <div id="adminPanel" hidden>
-        <div class="panel-header">
-          <div class="tab-list" role="tablist" aria-label="Panel admin">
-            <button class="tab" role="tab" aria-selected="true" aria-controls="admin-pending" id="admin-pending-btn">Pendientes</button>
-            <button class="tab" role="tab" aria-selected="false" aria-controls="admin-products" id="admin-products-btn">Productos</button>
-            <button class="tab" role="tab" aria-selected="false" aria-controls="admin-taxonomy" id="admin-taxonomy-btn">Categorías</button>
-            <button class="tab" role="tab" aria-selected="false" aria-controls="admin-messages" id="admin-messages-btn">Mensajes</button>
-            <button class="tab" role="tab" aria-selected="false" aria-controls="admin-notifications" id="admin-notifications-btn">Notificaciones</button>
-            <button class="tab" role="tab" aria-selected="false" aria-controls="admin-about" id="admin-about-btn">Conóceme</button>
+            <div class="panel-header">
+              <div class="tab-list" role="tablist" aria-label="Panel admin">
+                <button class="tab" role="tab" aria-selected="true" aria-controls="admin-pending" id="admin-pending-btn">Pendientes</button>
+                <button class="tab" role="tab" aria-selected="false" aria-controls="admin-products" id="admin-products-btn">Productos</button>
+                <button class="tab" role="tab" aria-selected="false" aria-controls="admin-expired" id="admin-expired-btn">Expirados</button>
+                <button class="tab" role="tab" aria-selected="false" aria-controls="admin-taxonomy" id="admin-taxonomy-btn">Categorías</button>
+                <button class="tab" role="tab" aria-selected="false" aria-controls="admin-messages" id="admin-messages-btn">Mensajes</button>
+                <button class="tab" role="tab" aria-selected="false" aria-controls="admin-notifications" id="admin-notifications-btn">Notificaciones</button>
+                <button class="tab" role="tab" aria-selected="false" aria-controls="admin-about" id="admin-about-btn">Conóceme</button>
             <button class="tab" role="tab" aria-selected="false" aria-controls="admin-settings" id="admin-settings-btn">Ajustes</button>
           </div>
           <button class="btn btn-ghost" id="adminLogout" type="button">Cerrar sesión</button>
@@ -899,6 +912,17 @@
               <span>Dirección o zona aproximada (opcional)</span>
               <input type="text" id="productAddress" placeholder="Ej. Colonia Roma, CDMX">
             </label>
+            <div class="location-actions">
+              <button class="btn btn-ghost" id="productMapSearch" type="button">Buscar en mapa</button>
+              <label class="checkbox">
+                <input type="checkbox" id="productMapManual">
+                <span>Colocar pin manualmente</span>
+              </label>
+            </div>
+            <div class="map-panel">
+              <div class="map-preview" id="productMap" aria-label="Mapa de ubicación"></div>
+              <p class="muted small" id="productMapStatus">Selecciona una dirección o coloca el pin en el mapa.</p>
+            </div>
             <div class="field-row">
               <label class="checkbox">
                 <input type="checkbox" id="productShowPhone">
@@ -914,9 +938,29 @@
               </label>
             </div>
             <label class="checkbox">
+              <input type="checkbox" id="productShowAddress">
+              <span>Mostrar texto de ubicación</span>
+            </label>
+            <label class="checkbox">
               <input type="checkbox" id="productPrivate">
               <span>Producto visible solo en Especiales</span>
             </label>
+            <label class="field">
+              <span>Duración del anuncio</span>
+              <select id="productExpiration">
+                <option value="forever">Indefinido</option>
+                <option value="7d">7 días</option>
+                <option value="30d">30 días</option>
+                <option value="3m">3 meses</option>
+                <option value="6m">6 meses</option>
+                <option value="date">Fecha específica</option>
+              </select>
+            </label>
+            <label class="field" id="productExpirationDateField" hidden>
+              <span>Fecha de caducidad</span>
+              <input type="date" id="productExpirationDate">
+            </label>
+            <p class="muted small" id="productExpirationHelp"></p>
             <label class="checkbox">
               <input type="checkbox" id="productSchedule">
               <span>Agregar calendario de fechas</span>
@@ -934,10 +978,16 @@
             <div class="form-actions">
               <button class="btn btn-primary" type="submit">Guardar</button>
               <button class="btn btn-whatsapp" id="adminWhatsApp" type="button">Avisar por WhatsApp</button>
+              <button class="btn btn-ghost" id="reactivateProduct" type="button" hidden>Reactivar</button>
               <button class="btn btn-ghost" id="cancelProduct" type="button">Cancelar</button>
             </div>
             <p id="productFormStatus" class="muted" aria-live="polite"></p>
           </form>
+        </div>
+
+        <div id="admin-expired" class="tab-panel" role="tabpanel" aria-labelledby="admin-expired-btn" hidden>
+          <p class="muted">Anuncios expirados (no visibles en el catálogo público).</p>
+          <div id="adminExpiredList" class="admin-list"></div>
         </div>
 
         <div id="admin-taxonomy" class="tab-panel" role="tabpanel" aria-labelledby="admin-taxonomy-btn" hidden>
@@ -1074,7 +1124,12 @@
       <img id="lightboxImage" alt="">
     </div>
   </div>
+  <audio id="holidayAudio" preload="auto">
+    <source src="assets/audio/navidad.mp3" type="audio/mpeg">
+  </audio>
+  <button class="btn btn-ghost music-toggle" id="toggleMusic" type="button" aria-pressed="false" hidden>Reproducir música</button>
 
-  <script src="js/scripts.js?v=20251227-0044"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="js/scripts.js?v=20250214-1530"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Corregir el botón “Editar” en el panel admin que no abría el formulario tras re-renderizar la lista. 
- Añadir una experiencia de visualización de imágenes potente: lupa con desplazamiento por cursor y visor a pantalla completa al hacer click. 
- Permitir que anunciantes coloquen o busquen coordenadas en mapa (sin API key) y que Admin controle la visibilidad pública. 
- Soportar caducidad editable de anuncios y una reproducción de música navideña con control por usuario.

### Description
- Repare la gestión de acciones en el admin usando delegación de eventos en `#adminPanel` y nuevos `data-action`/`data-id` para evitar listeners perdidos, además de añadir la pestaña “Expirados”; archivos cambiados: `js/scripts.js`, `index.html`, `admin.php`, `courses.html`.
- Implementé lupa de gran aumento con `zoom-lens` y cursor-driven background-position más un lightbox full-screen que cierra con X, click fuera y ESC; estilos en `css/styles.css` y hooks en `js/scripts.js`.
- Integré Leaflet + OpenStreetMap y Nominatim para búsqueda por dirección y pin manual, con gestores de mapa por formulario, campos de modelo (`lat`, `lng`, `locationMode`, `showMapPublic`, `showAddressPublic`, `expiresAt`, `pinnedForever`) y renderizado condicional del mapa; cambios en `index.html`, `js/scripts.js`, `css/styles.css`.
- Añadí control de expiración del anuncio editable desde Admin (presets e fecha específica), mantenimiento que marca expirados y UI para reactivar; además se añadió un `<audio>` placeholder y `assets/audio/README.md` con instrucciones y un botón discreto para iniciar la música si autoplay falla.

### Testing
- Levanté un servidor estático local y capturé una captura de pantalla con Playwright para verificar que la página carga y los cambios se integran sin errores aparentes (screenshot generada).
- Probé el flujo admin (abrir modal, editar producto, guardar, re-editar) manualmente durante la sesión de desarrollo y confirmé que la delegación abre el formulario repetidamente; (funcional en entorno local).
- Verifiqué que las hojas `<link>` y `<script>` principales fueron apuntadas a las mismas fuentes de verdad y se actualizó el cache-busting a `?v=20250214-1530` en los HTMLs modificados.
- No se ejecutaron pruebas de integración automatizadas adicionales en CI en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f3646e8bc832584f44e28694130ad)