### PR TITLE
Fix notification bubble dismissal, clear admin session on reload, and improve holiday music startup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1070,6 +1070,6 @@
   <button class="btn btn-ghost music-toggle" id="toggleMusic" type="button" aria-pressed="false" hidden>Reproducir música</button>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-  <script src="js/scripts.js?v=20250214-1530"></script>
+  <script src="js/scripts.js?v=20251226-2300"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Ensure the notification bubble can be reliably dismissed (click/tap/keyboard) and that dismissal persists for the session.
- Improve security by preventing the ADMIN session from persisting across page refresh/close events.
- Make the holiday music robust against autoplay blocking and missing assets by starting on the user’s first gesture and providing a clear fallback.

### Description
- Reinforced notification dismissal by updating `setupNotification` to capture `#dismissNotifications` with global handlers (click/touch/keyboard) and set `NOTIFICATION_BUBBLE_DISMISSED_KEY` in `sessionStorage`.
- Hardened the notification bubble open handler in `setupNotificationBubble` with `pointerdown`/`touchstart` handlers and kept the close behavior intact.
- Reworked `setupHolidayMusic` to start playback only after the first user gesture (`pointerdown`/`touchstart`), added a safe play flow with pause/resume toggle, error handler that disables the control and shows `"Música no disponible"`, and ensured the control state is accessible via `aria-pressed`.
- Forced admin session removal at init and on page lifecycle events by calling `sessionStorage.removeItem(ADMIN_SESSION_KEY)` and adding `pagehide` / `beforeunload` listeners, and bumped the script cache-buster in `index.html` to `v=20251226-2300`.
- Files changed: `js/scripts.js`, `index.html`.
- Important note: `assets/audio/navidad.mp3` is missing from the repository and must be uploaded to the server to enable music; otherwise the UI shows the fallback "Música no disponible".

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f6f9825508325803a1bebce886977)